### PR TITLE
Implement the bottom navigation bar redirection

### DIFF
--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -4,8 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
@@ -15,10 +19,17 @@ import com.example.triptracker.navigation.LaunchPermissionRequest
 import com.example.triptracker.view.HomeScreen
 import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.NavigationBar
 import com.example.triptracker.view.Route
+import com.example.triptracker.view.map.MapOverviewPreview
+import com.example.triptracker.view.map.RecordScreenPreview
 import com.example.triptracker.view.theme.TripTrackerTheme
+import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
+  // Private boolean that tracks the logging status
+  private var isLoggedIn = mutableStateOf(false)
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContent {
@@ -32,12 +43,35 @@ class MainActivity : ComponentActivity() {
 
           LaunchPermissionRequest(context = this)
 
-          // List of destinations for in app navigation
-          NavHost(navController = navController, startDestination = Route.LOGIN) {
-            composable(Route.LOGIN) {
-              LoginScreen(navigation) // TODO change this once more screens are added
+          // Start a coroutine to continuously check the isLoggedIn boolean
+          LaunchedEffect(Unit) {
+            while (true) {
+              isLoggedIn.value = navigation.getIsLoggedIn()
+              delay(1000)
             }
-            composable(Route.HOME) { HomeScreen(navigation) }
+          }
+
+          /** If logged in, display the app content with the bottom navigation bar */
+          if (isLoggedIn.value) {
+            Scaffold(bottomBar = { NavigationBar(navigation) }) { innerPadding ->
+              // List of destinations for in app navigation
+              NavHost(
+                  navController = navController,
+                  startDestination = Route.HOME,
+                  Modifier.padding(innerPadding)) {
+                    composable(Route.HOME) { HomeScreen(navigation) }
+                    composable(Route.MAPS) { MapOverviewPreview() }
+                    composable(Route.RECORD) { RecordScreenPreview() }
+                    composable(Route.PROFILE) {
+                      // TODO: Call the profile composable
+                    }
+                  }
+            }
+          }
+
+          /** If not logged in, display the logging screen without the bottom navigation bar */
+          else {
+            LoginScreen(navigation)
           }
         }
       }

--- a/app/src/main/java/com/example/triptracker/view/LoginScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/LoginScreen.kt
@@ -100,30 +100,16 @@ fun LoginScreen(navigation: Navigation, loginViewModel: LoginViewModel = viewMod
   val loginResult = loginViewModel.authResult.observeAsState()
   when (val response = loginResult.value) {
     is AuthResponse.Success -> {
-      LoginResponseOk(
-          result = response.data,
-          onSignOut = {
-            authenticator.signOut()
-            navigation.navController.navigate(Route.LOGIN)
-          },
-          navigation = navigation)
-      //            onNavigateToOverview() //TODO call this once new screens are added
-      Box(
-          modifier = Modifier.fillMaxSize(),
-          contentAlignment = Alignment.BottomCenter // Aligns children to the bottom center
-          ) {
-            // Display the login response OK information
-            LoginResponseOk(
-                result = response.data,
-                onSignOut = {
-                  authenticator.signOut()
-                  navigation.navController.navigate(Route.LOGIN)
-                },
-                navigation = navigation)
+      // LoginResponseOk(
+      //     result = response.data,
+      //     onSignOut = {
+      //       authenticator.signOut()
+      //       navigation.navController.navigate(Route.LOGIN)
+      //     },
+      //     navigation = navigation)
+      // onNavigateToOverview() // TODO call this once new screens are added
 
-            // Overlay the navigation bar at the bottom of the screen
-            NavigationBar(navigation)
-          }
+      navigation.setIsLoggedIn()
     }
     is AuthResponse.Error -> {
       LoginResponseFailure(message = response.errorMessage)

--- a/app/src/main/java/com/example/triptracker/view/Navigation.kt
+++ b/app/src/main/java/com/example/triptracker/view/Navigation.kt
@@ -37,6 +37,25 @@ private val TOP_LEVEL_DESTINATIONS =
  * non blocking way. Allows to navigate to a specific TopLevelDestination.
  */
 class Navigation(val navController: NavHostController) {
+
+  /** Private boolean that tracks the logging status, since it influences the navigation behavior */
+  private var isLoggedIn = false
+
+  /** Getter for the isLoggedIn boolean */
+  fun getIsLoggedIn(): Boolean {
+    return isLoggedIn
+  }
+
+  /** Setter for the isLoggedIn boolean */
+  fun setIsLoggedIn() {
+    isLoggedIn = true
+  }
+
+  /** Reset for the isLoggedIn boolean */
+  fun resetIsLoggedIn() {
+    isLoggedIn = false
+  }
+
   fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
       // Pop up to the start destination of the graph to

--- a/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 /**
- * @param navigation: Navigation object to navigate to other screens
+ * @param navigation (Navigation): Navigation object to navigate to other screens
  * @brief NavigationBar composable that displays the bottom navigation bar once logged in
  */
 fun NavigationBar(navigation: Navigation) {
@@ -40,7 +40,7 @@ fun NavigationBar(navigation: Navigation) {
                 selectedItem.intValue = index
 
                 /** TODO uncomment this once the navigation and the other tabs are implemented */
-                // navigation.navigateTo(destinations[selectedItem])
+                navigation.navigateTo(destinations[selectedItem.intValue])
               })
         }
       },


### PR DESCRIPTION
### Implement the bottom navigation bar redirection

This PR will allow user to have the finally navigate through the main app destinations/tabs.

Here is a quick overview of what was done :

- In `Navigation.kt`, added a isLoggedIn status tracking since it influences the navigation behavior.
- In `MainActivity.kt`, added a listener to isLoggedIn such that when the boolean is false, it displays the LoggingScreen, otherwise we have the classic app content with the bottom navigation bar.
- Defined a scaffold so that the navigation bar appears over each of the four main tabs.
- Adjusted the padding in order to prevent the navigation bar from being displayed above the tabs and from hiding content.


Visualization of the implementations:
https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/c566d16d-57da-4ce0-bfb7-ce6e4ffdf19e

Note that the profile redirection is left to be linked, but will be soon done.