### PR TITLE
Smooth camera navigation map overview and refactor code of maps screens

### DIFF
--- a/app/src/main/java/com/example/triptracker/view/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/HomeScreen.kt
@@ -43,7 +43,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
-import com.example.triptracker.view.theme.md_theme_gray
+import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_black
 import com.example.triptracker.view.theme.md_theme_light_onPrimary
 import com.example.triptracker.view.theme.md_theme_orange
@@ -116,7 +116,7 @@ fun DisplayItinerary(
                 fontFamily = FontFamily(Font(R.font.montserrat_regular)),
                 fontWeight = FontWeight.Normal,
                 fontSize = 14.sp,
-                color = md_theme_gray)
+                color = md_theme_grey)
             Spacer(modifier = Modifier.width(120.dp))
             Icon(
                 imageVector = Icons.Outlined.Star,
@@ -142,7 +142,7 @@ fun DisplayItinerary(
               text = "$pinListString",
               fontSize = 14.sp,
               fontFamily = FontFamily(Font(R.font.montserrat_medium)),
-              color = md_theme_gray)
+              color = md_theme_grey)
         }
       }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
@@ -1,0 +1,62 @@
+package com.example.triptracker.view.map
+
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
+import com.example.triptracker.view.theme.Montserrat
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.CameraPositionState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun DisplayCenterLocationButton(coroutineScope : CoroutineScope, deviceLocation : LatLng, cameraPositionState : CameraPositionState) {
+
+        Icon(
+            imageVector = Icons.Outlined.LocationOn,
+            contentDescription = "Center on device location",
+            tint = Color.White,
+            modifier =
+            Modifier
+                .width(50.dp)
+                .height(50.dp)
+                .background(transparentGray, shape = RoundedCornerShape(16.dp))
+                .padding(10.dp)
+                .clickable {
+                    coroutineScope.launch {
+                        cameraPositionState.animate(
+                            CameraUpdateFactory.newCameraPosition(
+                                CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+                            )
+                        )
+                    }
+                }
+
+        )
+
+}

--- a/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.example.triptracker.view.theme.md_theme_gray
+import com.example.triptracker.view.theme.md_theme_grey
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -22,12 +22,22 @@ import com.google.maps.android.compose.CameraPositionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+// Gradient for the top bar of the map screen. This is common for the MapOverview and RecordScreen
 val gradient =
     Brush.verticalGradient(
         colorStops = arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.3f to Color.Transparent))
 
+// Default location for the map when starting the app and when the user location is not available
+// This is the location of the EPFL campus
 val DEFAULT_LOCATION = LatLng(46.518831258, 6.559331096)
 
+/**
+ * Display a button to center the map on the device location
+ *
+ * @param coroutineScope the coroutine scope to launch the animation
+ * @param deviceLocation the location of the device
+ * @param cameraPositionState the state of the camera position
+ */
 @Composable
 fun DisplayCenterLocationButton(
     coroutineScope: CoroutineScope,
@@ -42,7 +52,7 @@ fun DisplayCenterLocationButton(
       modifier =
           Modifier.width(50.dp)
               .height(50.dp)
-              .background(md_theme_gray, shape = RoundedCornerShape(16.dp))
+              .background(md_theme_grey, shape = RoundedCornerShape(16.dp))
               .padding(10.dp)
               .clickable {
                 coroutineScope.launch {

--- a/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
@@ -21,10 +21,12 @@ import com.google.maps.android.compose.CameraPositionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-
 val gradient =
     Brush.verticalGradient(
         colorStops = arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.3f to Color.Transparent))
+
+val DEFAULT_LOCATION = LatLng(46.518831258, 6.559331096)
+
 @Composable
 fun DisplayCenterLocationButton(
     coroutineScope: CoroutineScope,

--- a/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -20,6 +21,10 @@ import com.google.maps.android.compose.CameraPositionState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+
+val gradient =
+    Brush.verticalGradient(
+        colorStops = arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.3f to Color.Transparent))
 @Composable
 fun DisplayCenterLocationButton(
     coroutineScope: CoroutineScope,

--- a/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.example.triptracker.view.theme.md_theme_gray
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -41,7 +42,7 @@ fun DisplayCenterLocationButton(
       modifier =
           Modifier.width(50.dp)
               .height(50.dp)
-              .background(transparentGray, shape = RoundedCornerShape(16.dp))
+              .background(md_theme_gray, shape = RoundedCornerShape(16.dp))
               .padding(10.dp)
               .clickable {
                 coroutineScope.launch {

--- a/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapElements.kt
@@ -1,32 +1,18 @@
 package com.example.triptracker.view.map
 
-
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LocationOn
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstraintLayout
-import com.example.triptracker.view.theme.Montserrat
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -35,28 +21,26 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @Composable
-fun DisplayCenterLocationButton(coroutineScope : CoroutineScope, deviceLocation : LatLng, cameraPositionState : CameraPositionState) {
+fun DisplayCenterLocationButton(
+    coroutineScope: CoroutineScope,
+    deviceLocation: LatLng,
+    cameraPositionState: CameraPositionState
+) {
 
-        Icon(
-            imageVector = Icons.Outlined.LocationOn,
-            contentDescription = "Center on device location",
-            tint = Color.White,
-            modifier =
-            Modifier
-                .width(50.dp)
-                .height(50.dp)
-                .background(transparentGray, shape = RoundedCornerShape(16.dp))
-                .padding(10.dp)
-                .clickable {
-                    coroutineScope.launch {
-                        cameraPositionState.animate(
-                            CameraUpdateFactory.newCameraPosition(
-                                CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-                            )
-                        )
-                    }
+  Icon(
+      imageVector = Icons.Outlined.LocationOn,
+      contentDescription = "Center on device location",
+      tint = Color.White,
+      modifier =
+          Modifier.width(50.dp)
+              .height(50.dp)
+              .background(transparentGray, shape = RoundedCornerShape(16.dp))
+              .padding(10.dp)
+              .clickable {
+                coroutineScope.launch {
+                  cameraPositionState.animate(
+                      CameraUpdateFactory.newCameraPosition(
+                          CameraPosition.fromLatLngZoom(deviceLocation, 17f)))
                 }
-
-        )
-
+              })
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -4,17 +4,27 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,6 +41,7 @@ import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
 import com.example.triptracker.viewmodel.MapViewModel
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -38,6 +49,7 @@ import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.rememberCameraPositionState
+import kotlinx.coroutines.launch
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
@@ -106,9 +118,10 @@ fun Map(
   val ui by remember { mutableStateOf(uiSettings) }
   val properties by remember { mutableStateOf(mapProperties) }
   var deviceLocation by remember { mutableStateOf(startLocation) }
+  val coroutineScope = rememberCoroutineScope()
 
   val cameraPositionState = rememberCameraPositionState {
-    position = CameraPosition.fromLatLngZoom(deviceLocation, 16f)
+    position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
   }
 
   // When the camera is moving, the city name is updated in the top bar with geo decoding
@@ -128,7 +141,7 @@ fun Map(
         context = context,
         onLocationFetched = {
           deviceLocation = it
-          cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 16f)
+          cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
         })
   }
 
@@ -159,25 +172,33 @@ fun Map(
           fontFamily = FontFamily.SansSerif,
           color = Color.Black)
 
-        if(ui.myLocationButtonEnabled && mapProperties.isMyLocationEnabled) {
-            IconButton(
-                onClick = {
-                    getCurrentLocation(
-                        context = context,
-                        onLocationFetched = {
-                            deviceLocation = it
-                            cameraPositionState.position =
-                                CameraPosition.fromLatLngZoom(deviceLocation, 16f)
-                        })
-                }) {
-                Icon(
-                    modifier = Modifier.padding(40.dp),
-                    painter = painterResource(id = R.drawable.ic_gps_fixed),
-                    contentDescription = null
-                )
-            }
-        }
     }
+      if(ui.myLocationButtonEnabled && mapProperties.isMyLocationEnabled) {
+          Row(
+              modifier = Modifier.align(Alignment.BottomStart).padding(horizontal = 35.dp, vertical = 62.dp),
+              horizontalArrangement = Arrangement.Center) {
+              Icon(
+                  imageVector = Icons.Outlined.LocationOn,
+                  contentDescription = "Center on device location",
+                  tint = Color.White,
+                  modifier =
+                  Modifier.width(50.dp)
+                      .height(50.dp)
+                      .background(transparentGray, shape = RoundedCornerShape(16.dp))
+                      .padding(10.dp)
+                      .align(Alignment.CenterVertically)
+                      .clickable {
+                          coroutineScope.launch {
+                              cameraPositionState.animate(
+                                  CameraUpdateFactory.newCameraPosition(
+                                      CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+                                  )
+                              )
+                          }
+                      })
+              Spacer(modifier = Modifier.width(50.dp))
+          }
+      }
   }
 }
 

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -134,9 +134,7 @@ fun Map(
         })
   }
 
-    val gradient =
-        Brush.verticalGradient(
-            colorStops = arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.3f to Color.Transparent))
+
 
   // Displays the map
   Box() {

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -23,12 +23,14 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
+import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.viewmodel.MapViewModel
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -132,10 +134,9 @@ fun Map(
         })
   }
 
-  val gradient =
-      Brush.verticalGradient(
-          colorStops =
-              arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.15f to Color.Transparent))
+    val gradient =
+        Brush.verticalGradient(
+            colorStops = arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.3f to Color.Transparent))
 
   // Displays the map
   Box() {
@@ -156,8 +157,9 @@ fun Map(
           text = mapViewModel.cityNameState.value,
           modifier = Modifier.padding(30.dp).align(Alignment.TopCenter),
           fontSize = 24.sp,
-          fontFamily = FontFamily.SansSerif,
-          color = Color.Black)
+          fontFamily = Montserrat,
+          fontWeight = FontWeight.SemiBold,
+          color = lightDark)
     }
     Row(
         modifier = Modifier.align(Alignment.BottomStart),

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -159,20 +159,24 @@ fun Map(
           fontFamily = FontFamily.SansSerif,
           color = Color.Black)
 
-      IconButton(
-          onClick = {
-            getCurrentLocation(
-                context = context,
-                onLocationFetched = {
-                  deviceLocation = it
-                  cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 16f)
-                })
-          }) {
-            Icon(
-                modifier = Modifier.padding(40.dp),
-                painter = painterResource(id = R.drawable.ic_gps_fixed),
-                contentDescription = null)
-          }
+        if(ui.myLocationButtonEnabled && mapProperties.isMyLocationEnabled) {
+            IconButton(
+                onClick = {
+                    getCurrentLocation(
+                        context = context,
+                        onLocationFetched = {
+                            deviceLocation = it
+                            cameraPositionState.position =
+                                CameraPosition.fromLatLngZoom(deviceLocation, 16f)
+                        })
+                }) {
+                Icon(
+                    modifier = Modifier.padding(40.dp),
+                    painter = painterResource(id = R.drawable.ic_gps_fixed),
+                    contentDescription = null
+                )
+            }
+        }
     }
   }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -58,7 +58,7 @@ fun MapOverview(
   var deviceLocation = LatLng(46.519962, 6.633597)
   var mapProperties =
       MapProperties(
-          mapType = MapType.SATELLITE, isMyLocationEnabled = checkForLocationPermission(context))
+          mapType = MapType.NORMAL, isMyLocationEnabled = checkForLocationPermission(context))
   var uiSettings = MapUiSettings(myLocationButtonEnabled = checkForLocationPermission(context))
 
   getCurrentLocation(context = context, onLocationFetched = { deviceLocation = it })
@@ -74,11 +74,11 @@ fun MapOverview(
     false -> {
       AllowLocationPermission(
           onPermissionGranted = {
-            mapProperties = MapProperties(mapType = MapType.SATELLITE, isMyLocationEnabled = true)
+            mapProperties = MapProperties(mapType = MapType.NORMAL, isMyLocationEnabled = true)
             uiSettings = MapUiSettings(myLocationButtonEnabled = true)
           },
           onPermissionDenied = {
-            mapProperties = MapProperties(mapType = MapType.SATELLITE, isMyLocationEnabled = false)
+            mapProperties = MapProperties(mapType = MapType.NORMAL, isMyLocationEnabled = false)
             uiSettings = MapUiSettings(myLocationButtonEnabled = false)
           })
     }

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -56,7 +55,7 @@ fun MapOverview(
 ) {
 
   // The device location is set to EPFL by default
-  var deviceLocation = LatLng(46.519962, 6.633597)
+  var deviceLocation = DEFAULT_LOCATION
   var mapProperties =
       MapProperties(
           mapType = MapType.NORMAL, isMyLocationEnabled = checkForLocationPermission(context))
@@ -133,8 +132,6 @@ fun Map(
           cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
         })
   }
-
-
 
   // Displays the map
   Box() {

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -4,25 +4,12 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.LocationOn
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,19 +22,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.triptracker.R
 import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
-import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.viewmodel.MapViewModel
-import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -55,7 +37,6 @@ import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.rememberCameraPositionState
-import kotlinx.coroutines.launch
 
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
@@ -161,44 +142,35 @@ fun Map(
     Box(modifier = Modifier.fillMaxSize()) {
       GoogleMap(
           modifier =
-          Modifier
-              .matchParentSize()
-              .background(
-                  brush =
-                  Brush.verticalGradient(colors = listOf(Color.Transparent, Color.Black))
-              ),
+              Modifier.matchParentSize()
+                  .background(
+                      brush =
+                          Brush.verticalGradient(colors = listOf(Color.Transparent, Color.Black))),
           cameraPositionState = cameraPositionState,
           properties = properties,
           uiSettings = ui,
       ) {}
     }
-    Box(modifier = Modifier
-        .matchParentSize()
-        .background(gradient)
-        .align(Alignment.TopCenter)) {
+    Box(modifier = Modifier.matchParentSize().background(gradient).align(Alignment.TopCenter)) {
       Text(
           text = mapViewModel.cityNameState.value,
-          modifier = Modifier
-              .padding(30.dp)
-              .align(Alignment.TopCenter),
+          modifier = Modifier.padding(30.dp).align(Alignment.TopCenter),
           fontSize = 24.sp,
           fontFamily = FontFamily.SansSerif,
           color = Color.Black)
-            }
-      Row(
-          modifier = Modifier.align(Alignment.BottomStart),
-          horizontalArrangement = Arrangement.Start) {
+    }
+    Row(
+        modifier = Modifier.align(Alignment.BottomStart),
+        horizontalArrangement = Arrangement.Start) {
           if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
-              Box(modifier = Modifier.padding(horizontal = 35.dp, vertical = 65.dp)) {
-                  DisplayCenterLocationButton(
-                      coroutineScope = coroutineScope,
-                      deviceLocation = deviceLocation,
-                      cameraPositionState = cameraPositionState
-                  )
-              }
+            Box(modifier = Modifier.padding(horizontal = 35.dp, vertical = 65.dp)) {
+              DisplayCenterLocationButton(
+                  coroutineScope = coroutineScope,
+                  deviceLocation = deviceLocation,
+                  cameraPositionState = cameraPositionState)
+            }
           }
-
-      }
+        }
   }
 }
 

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -30,6 +30,7 @@ import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
 import com.example.triptracker.view.theme.Montserrat
+import com.example.triptracker.view.theme.md_theme_light_dark
 import com.example.triptracker.viewmodel.MapViewModel
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
@@ -154,7 +155,7 @@ fun Map(
           fontSize = 24.sp,
           fontFamily = Montserrat,
           fontWeight = FontWeight.SemiBold,
-          color = lightDark)
+          color = md_theme_light_dark)
     }
     Row(
         modifier = Modifier.align(Alignment.BottomStart),

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -19,6 +21,8 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -33,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -40,6 +45,7 @@ import com.example.triptracker.R
 import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
+import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.viewmodel.MapViewModel
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
@@ -155,49 +161,43 @@ fun Map(
     Box(modifier = Modifier.fillMaxSize()) {
       GoogleMap(
           modifier =
-              Modifier.matchParentSize()
-                  .background(
-                      brush =
-                          Brush.verticalGradient(colors = listOf(Color.Transparent, Color.Black))),
+          Modifier
+              .matchParentSize()
+              .background(
+                  brush =
+                  Brush.verticalGradient(colors = listOf(Color.Transparent, Color.Black))
+              ),
           cameraPositionState = cameraPositionState,
           properties = properties,
           uiSettings = ui,
       ) {}
     }
-    Box(modifier = Modifier.matchParentSize().background(gradient).align(Alignment.TopCenter)) {
+    Box(modifier = Modifier
+        .matchParentSize()
+        .background(gradient)
+        .align(Alignment.TopCenter)) {
       Text(
           text = mapViewModel.cityNameState.value,
-          modifier = Modifier.padding(30.dp).align(Alignment.TopCenter),
+          modifier = Modifier
+              .padding(30.dp)
+              .align(Alignment.TopCenter),
           fontSize = 24.sp,
           fontFamily = FontFamily.SansSerif,
           color = Color.Black)
-
-    }
-      if(ui.myLocationButtonEnabled && mapProperties.isMyLocationEnabled) {
-          Row(
-              modifier = Modifier.align(Alignment.BottomStart).padding(horizontal = 35.dp, vertical = 62.dp),
-              horizontalArrangement = Arrangement.Center) {
-              Icon(
-                  imageVector = Icons.Outlined.LocationOn,
-                  contentDescription = "Center on device location",
-                  tint = Color.White,
-                  modifier =
-                  Modifier.width(50.dp)
-                      .height(50.dp)
-                      .background(transparentGray, shape = RoundedCornerShape(16.dp))
-                      .padding(10.dp)
-                      .align(Alignment.CenterVertically)
-                      .clickable {
-                          coroutineScope.launch {
-                              cameraPositionState.animate(
-                                  CameraUpdateFactory.newCameraPosition(
-                                      CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-                                  )
-                              )
-                          }
-                      })
-              Spacer(modifier = Modifier.width(50.dp))
+            }
+      Row(
+          modifier = Modifier.align(Alignment.BottomStart),
+          horizontalArrangement = Arrangement.Start) {
+          if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
+              Box(modifier = Modifier.padding(horizontal = 35.dp, vertical = 65.dp)) {
+                  DisplayCenterLocationButton(
+                      coroutineScope = coroutineScope,
+                      deviceLocation = deviceLocation,
+                      cameraPositionState = cameraPositionState
+                  )
+              }
           }
+
       }
   }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -49,6 +49,9 @@ import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
 import com.example.triptracker.view.theme.Montserrat
+import com.example.triptracker.view.theme.md_theme_gray
+import com.example.triptracker.view.theme.md_theme_light_dark
+import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.RecordViewModel
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
@@ -62,13 +65,6 @@ import com.google.maps.android.compose.rememberCameraPositionState
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-
-// Define color constants
-val lightDark = Color(0xFF1D2022)
-val redFox = Color(0xFFD4622B)
-// two shades of gray, one transparent
-val lightGray = Color(0xFFC0C7CD)
-val transparentGray = Color(0xC0C0C7CD)
 
 // Define the delay for the location update
 const val DELAY = 5000L
@@ -177,14 +173,15 @@ fun Map(
               Modifier.matchParentSize()
                   .background(
                       brush =
-                          Brush.verticalGradient(colors = listOf(Color.Transparent, lightDark))),
+                          Brush.verticalGradient(
+                              colors = listOf(Color.Transparent, md_theme_light_dark))),
           cameraPositionState = cameraPositionState,
           properties = properties,
           uiSettings = ui,
       ) {
         Polyline(
             points = localLatLngList.toList(),
-            color = redFox,
+            color = md_theme_orange,
             width = 15f,
         )
       }
@@ -198,7 +195,7 @@ fun Map(
           fontSize = 24.sp,
           fontFamily = Montserrat,
           fontWeight = FontWeight.SemiBold,
-          color = lightDark)
+          color = md_theme_light_dark)
     }
 
     // Display start window
@@ -231,7 +228,7 @@ fun Map(
               modifier = Modifier.padding(50.dp).fillMaxWidth(0.6f).fillMaxHeight(0.1f),
               colors =
                   ButtonDefaults.filledTonalButtonColors(
-                      containerColor = redFox, contentColor = Color.White),
+                      containerColor = md_theme_orange, contentColor = Color.White),
           ) {
             Text(
                 text = if (viewModel.isRecording()) "Stop" else "Start",
@@ -279,7 +276,7 @@ fun StartWindow(viewModel: RecordViewModel) {
                     modifier =
                         Modifier.fillMaxWidth(0.9f)
                             .fillMaxHeight(0.5f)
-                            .background(lightDark, shape = RoundedCornerShape(35.dp))
+                            .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp))
                             .align(Alignment.Center)) {
                       Row(
                           modifier = Modifier.fillMaxSize(),
@@ -313,7 +310,7 @@ fun StartWindow(viewModel: RecordViewModel) {
                     modifier =
                         Modifier.fillMaxWidth(0.9f)
                             .fillMaxHeight(0.45f)
-                            .background(lightDark, shape = RoundedCornerShape(35.dp))
+                            .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp))
                             .align(Alignment.Center)) {
                       Row(
                           modifier =
@@ -332,14 +329,15 @@ fun StartWindow(viewModel: RecordViewModel) {
                                     Modifier.align(Alignment.CenterVertically).fillMaxHeight(0.6f),
                                 colors =
                                     ButtonDefaults.filledTonalButtonColors(
-                                        containerColor = Color.White, contentColor = lightDark),
+                                        containerColor = Color.White,
+                                        contentColor = md_theme_light_dark),
                             ) {
                               Text(
                                   text = if (viewModel.isPaused.value) "Resume" else "Pause",
                                   fontSize = 14.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.SemiBold,
-                                  color = lightDark)
+                                  color = md_theme_light_dark)
                             }
                             Row(
                                 modifier = Modifier.align(Alignment.CenterVertically),
@@ -350,7 +348,7 @@ fun StartWindow(viewModel: RecordViewModel) {
                                       fontSize = 14.sp,
                                       fontFamily = Montserrat,
                                       fontWeight = FontWeight.SemiBold,
-                                      color = transparentGray)
+                                      color = md_theme_gray)
                                   Spacer(modifier = Modifier.width(20.dp))
                                   IconButton(
                                       onClick = { /*TODO*/},
@@ -362,7 +360,7 @@ fun StartWindow(viewModel: RecordViewModel) {
                                     Icon(
                                         imageVector = Icons.Outlined.Add,
                                         contentDescription = "Add spot",
-                                        tint = lightDark,
+                                        tint = md_theme_light_dark,
                                         modifier = Modifier.size(30.dp))
                                   }
                                 }

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -82,7 +82,7 @@ const val DELAY = 5000L
 @Composable
 fun RecordScreen(context: Context, viewModel: RecordViewModel = RecordViewModel()) {
   // default device location is EPFL
-  var deviceLocation = LatLng(46.518831258, 6.559331096)
+  var deviceLocation = DEFAULT_LOCATION
 
   // Default map properties and UI settings
   var mapProperties =

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -49,7 +49,7 @@ import com.example.triptracker.navigation.AllowLocationPermission
 import com.example.triptracker.navigation.checkForLocationPermission
 import com.example.triptracker.navigation.getCurrentLocation
 import com.example.triptracker.view.theme.Montserrat
-import com.example.triptracker.view.theme.md_theme_gray
+import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
 import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.RecordViewModel
@@ -113,6 +113,8 @@ fun RecordScreen(context: Context, viewModel: RecordViewModel = RecordViewModel(
  * @param context The application context.
  * @param viewModel The RecordViewModel instance.
  * @param startLocation The starting location.
+ * @param mapProperties: The properties of the map (type, location enabled)
+ * @param uiSettings: The settings of the map (location button enabled)
  */
 @Composable
 fun Map(
@@ -348,7 +350,7 @@ fun StartWindow(viewModel: RecordViewModel) {
                                       fontSize = 14.sp,
                                       fontFamily = Montserrat,
                                       fontWeight = FontWeight.SemiBold,
-                                      color = md_theme_gray)
+                                      color = md_theme_grey)
                                   Spacer(modifier = Modifier.width(20.dp))
                                   IconButton(
                                       onClick = { /*TODO*/},

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -169,11 +169,6 @@ fun Map(
     }
   }
 
-  // Define gradient for top bar
-  val gradient =
-      Brush.verticalGradient(
-          colorStops = arrayOf(0.0f to Color.White, 0.1f to Color.White, 0.3f to Color.Transparent))
-
   // Display the map
   Box {
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,7 +15,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -24,7 +22,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
-import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -122,12 +119,18 @@ fun RecordScreen(context: Context, viewModel: RecordViewModel = RecordViewModel(
  * @param startLocation The starting location.
  */
 @Composable
-fun Map(context: Context, viewModel: RecordViewModel, startLocation: LatLng, mapProperties: MapProperties, uiSettings: MapUiSettings ) {
+fun Map(
+    context: Context,
+    viewModel: RecordViewModel,
+    startLocation: LatLng,
+    mapProperties: MapProperties,
+    uiSettings: MapUiSettings
+) {
   // Mutable state for the device location and the local LatLng list
   var deviceLocation by remember { mutableStateOf(startLocation) }
   val localLatLngList = remember { mutableStateListOf<LatLng>() }
-    val ui by remember { mutableStateOf(uiSettings) }
-    val properties by remember { mutableStateOf(mapProperties) }
+  val ui by remember { mutableStateOf(uiSettings) }
+  val properties by remember { mutableStateOf(mapProperties) }
 
   // Coroutine scope for the animations
   val coroutineScope = rememberCoroutineScope()
@@ -176,12 +179,10 @@ fun Map(context: Context, viewModel: RecordViewModel, startLocation: LatLng, map
     Box(modifier = Modifier.fillMaxSize()) {
       GoogleMap(
           modifier =
-          Modifier
-              .matchParentSize()
-              .background(
-                  brush =
-                  Brush.verticalGradient(colors = listOf(Color.Transparent, lightDark))
-              ),
+              Modifier.matchParentSize()
+                  .background(
+                      brush =
+                          Brush.verticalGradient(colors = listOf(Color.Transparent, lightDark))),
           cameraPositionState = cameraPositionState,
           properties = properties,
           uiSettings = ui,
@@ -195,15 +196,10 @@ fun Map(context: Context, viewModel: RecordViewModel, startLocation: LatLng, map
     }
 
     // Display gradient for top bar
-    Box(modifier = Modifier
-        .matchParentSize()
-        .background(gradient)
-        .align(Alignment.TopCenter)) {
+    Box(modifier = Modifier.matchParentSize().background(gradient).align(Alignment.TopCenter)) {
       Text(
           text = "Record",
-          modifier = Modifier
-              .padding(30.dp)
-              .align(Alignment.TopCenter),
+          modifier = Modifier.padding(30.dp).align(Alignment.TopCenter),
           fontSize = 24.sp,
           fontFamily = Montserrat,
           fontWeight = FontWeight.SemiBold,
@@ -217,15 +213,14 @@ fun Map(context: Context, viewModel: RecordViewModel, startLocation: LatLng, map
     Row(
         modifier = Modifier.align(Alignment.BottomCenter),
         horizontalArrangement = Arrangement.Center) {
-        if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
+          if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
             Box(modifier = Modifier.padding(horizontal = 0.dp, vertical = 60.dp)) {
-                DisplayCenterLocationButton(
-                    coroutineScope = coroutineScope,
-                    deviceLocation = deviceLocation,
-                    cameraPositionState = cameraPositionState
-                )
+              DisplayCenterLocationButton(
+                  coroutineScope = coroutineScope,
+                  deviceLocation = deviceLocation,
+                  cameraPositionState = cameraPositionState)
             }
-        }
+          }
 
           // Button to start/stop recording
           FilledTonalButton(
@@ -238,10 +233,7 @@ fun Map(context: Context, viewModel: RecordViewModel, startLocation: LatLng, map
                   viewModel.startRecording()
                 }
               },
-              modifier = Modifier
-                  .padding(50.dp)
-                  .fillMaxWidth(0.6f)
-                  .fillMaxHeight(0.1f),
+              modifier = Modifier.padding(50.dp).fillMaxWidth(0.6f).fillMaxHeight(0.1f),
               colors =
                   ButtonDefaults.filledTonalButtonColors(
                       containerColor = redFox, contentColor = Color.White),
@@ -279,10 +271,7 @@ fun StartWindow(viewModel: RecordViewModel) {
 
   // Display recording window if user is recording
   Column(
-      modifier = Modifier
-          .fillMaxHeight()
-          .fillMaxWidth()
-          .padding(top = 20.dp, bottom = 100.dp),
+      modifier = Modifier.fillMaxHeight().fillMaxWidth().padding(top = 20.dp, bottom = 100.dp),
       verticalArrangement = Arrangement.SpaceBetween) {
         // animate the visibility of the recording window
         AnimatedVisibility(
@@ -290,16 +279,13 @@ fun StartWindow(viewModel: RecordViewModel) {
             enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
             exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top)) {
               // Display the timer
-              Box(modifier = Modifier
-                  .fillMaxHeight(0.35f)
-                  .fillMaxWidth()) {
+              Box(modifier = Modifier.fillMaxHeight(0.35f).fillMaxWidth()) {
                 Box(
                     modifier =
-                    Modifier
-                        .fillMaxWidth(0.9f)
-                        .fillMaxHeight(0.5f)
-                        .background(lightDark, shape = RoundedCornerShape(35.dp))
-                        .align(Alignment.Center)) {
+                        Modifier.fillMaxWidth(0.9f)
+                            .fillMaxHeight(0.5f)
+                            .background(lightDark, shape = RoundedCornerShape(35.dp))
+                            .align(Alignment.Center)) {
                       Row(
                           modifier = Modifier.fillMaxSize(),
                           horizontalArrangement = Arrangement.SpaceEvenly) {
@@ -327,21 +313,17 @@ fun StartWindow(viewModel: RecordViewModel) {
             enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
             exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Bottom)) {
               // Display the pause/resume button and add spot button
-              Box(modifier = Modifier
-                  .fillMaxHeight(0.5f)
-                  .fillMaxWidth()) {
+              Box(modifier = Modifier.fillMaxHeight(0.5f).fillMaxWidth()) {
                 Box(
                     modifier =
-                    Modifier
-                        .fillMaxWidth(0.9f)
-                        .fillMaxHeight(0.45f)
-                        .background(lightDark, shape = RoundedCornerShape(35.dp))
-                        .align(Alignment.Center)) {
+                        Modifier.fillMaxWidth(0.9f)
+                            .fillMaxHeight(0.45f)
+                            .background(lightDark, shape = RoundedCornerShape(35.dp))
+                            .align(Alignment.Center)) {
                       Row(
                           modifier =
-                          Modifier
-                              .fillMaxSize()
-                              .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 10.dp),
+                              Modifier.fillMaxSize()
+                                  .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 10.dp),
                           horizontalArrangement = Arrangement.SpaceBetween) {
                             FilledTonalButton(
                                 onClick = {
@@ -352,9 +334,7 @@ fun StartWindow(viewModel: RecordViewModel) {
                                   }
                                 },
                                 modifier =
-                                Modifier
-                                    .align(Alignment.CenterVertically)
-                                    .fillMaxHeight(0.6f),
+                                    Modifier.align(Alignment.CenterVertically).fillMaxHeight(0.6f),
                                 colors =
                                     ButtonDefaults.filledTonalButtonColors(
                                         containerColor = Color.White, contentColor = lightDark),
@@ -380,10 +360,9 @@ fun StartWindow(viewModel: RecordViewModel) {
                                   IconButton(
                                       onClick = { /*TODO*/},
                                       modifier =
-                                      Modifier
-                                          .align(Alignment.CenterVertically)
-                                          .size(50.dp)
-                                          .background(Color.White, shape = CircleShape),
+                                          Modifier.align(Alignment.CenterVertically)
+                                              .size(50.dp)
+                                              .background(Color.White, shape = CircleShape),
                                   ) {
                                     Icon(
                                         imageVector = Icons.Outlined.Add,

--- a/app/src/main/java/com/example/triptracker/view/theme/Color.kt
+++ b/app/src/main/java/com/example/triptracker/view/theme/Color.kt
@@ -3,7 +3,8 @@ package com.example.triptracker.view.theme
 import androidx.compose.ui.graphics.Color
 
 val md_theme_orange = Color(0xFFD4622B)
-val md_theme_gray = Color(0xFFC0C7CD)
+val md_theme_gray = Color(0xC0C0C7CD)
+val md_theme_light_dark = Color(0xFF1D2022)
 
 val md_theme_light_black = Color(0xFF1D2022)
 val md_theme_light_primary = Color(0xFF00668A)

--- a/app/src/main/java/com/example/triptracker/view/theme/Color.kt
+++ b/app/src/main/java/com/example/triptracker/view/theme/Color.kt
@@ -3,7 +3,7 @@ package com.example.triptracker.view.theme
 import androidx.compose.ui.graphics.Color
 
 val md_theme_orange = Color(0xFFD4622B)
-val md_theme_gray = Color(0xC0C0C7CD)
+val md_theme_grey = Color(0xC0C0C7CD)
 val md_theme_light_dark = Color(0xFF1D2022)
 
 val md_theme_light_black = Color(0xFF1D2022)


### PR DESCRIPTION
This PR will adress the issues from #31 and also refactor some code so that the two GoogleMaps screens are similar and in harmony with the figma design.
Some code common to both screens was also refactored : 
- Colors were updated and put in the global theme of the app
- Font was updated to match the Figma design
- The center location button was updated so that they are both at the same place and only displayed if the location permissions are enabled

<image src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/79469048/b04e5540-5907-4fc3-aec5-c311816e27ee" width="312">
<image src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/79469048/2eae171b-ab07-4706-84ba-41982384b679" width="312">
