### PR TITLE
Implemented the Search bar in the `HomeScreen`

### DIFF
--- a/app/src/main/java/com/example/triptracker/view/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/HomeScreen.kt
@@ -21,18 +21,26 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.outlined.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -49,14 +57,36 @@ import com.example.triptracker.view.theme.md_theme_light_onPrimary
 import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.HomeViewModel
 
+/**
+ * HomeScreen composable that displays the list of itineraries
+ *
+ * @param navigation: Navigation object to use for navigation
+ * @param homeViewModel: HomeViewModel to use for fetching itineraries
+ */
 @Composable
 fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel()) {
   Log.d("HomeScreen", "Rendering HomeScreen")
+
+  // Filtered list of itineraries based on search query
+  val filteredList by homeViewModel.filteredItineraryList.observeAsState(initial = emptyList())
+  var isSearchActive by remember { mutableStateOf(false) }
+  val isNoResultFound =
+      remember(filteredList, isSearchActive) {
+        isSearchActive && filteredList.isEmpty() && homeViewModel.searchQuery.value!!.isNotEmpty()
+      }
+
   Scaffold(
       topBar = {
         // Assuming a SearchBar composable is defined elsewhere
         SearchBar(
-            modifier = Modifier.fillMaxWidth().padding(16.dp), onSearch = { /* handle search */})
+            onBackClicked = {
+              // Navigate back to the overview
+              val home = navigation.getTopLevelDestinations()[0].route
+              navigation.navController.navigate(home)
+            },
+            onSearchActivated = { isActive -> isSearchActive = isActive },
+            navigation = navigation,
+            isNoResultFound = isNoResultFound)
       },
       bottomBar = { NavigationBar(navigation) },
       modifier = Modifier.testTag("HomeScreen")) { innerPadding ->
@@ -85,6 +115,13 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
       }
 }
 
+/**
+ * Displays an itinerary in the list of itineraries
+ *
+ * @param itinerary: Itinerary object to display
+ * @param navigation: Navigation object to use for navigation
+ * @param pinNamesMap: Map of itinerary ID to list of pin names
+ */
 @Composable
 fun DisplayItinerary(
     itinerary: Itinerary,
@@ -152,6 +189,12 @@ fun DisplayItinerary(
       }
 }
 
+/**
+ * Helper function to convert a list of pin names to a string
+ *
+ * @param pinList: List of pin names
+ * @return String representation of the list of pin names
+ */
 fun convertPinListToString(pinList: List<String>): String {
   return if (pinList.size <= 3) {
     pinList.joinToString(", ")
@@ -162,19 +205,131 @@ fun convertPinListToString(pinList: List<String>): String {
   }
 }
 
+/**
+ * Displays the search bar at the top of the screen
+ *
+ * @param onBackClicked: Function to call when the back button is clicked
+ * @param onSearchActivated: Function to call when the search bar is activated
+ * @param viewModel: HomeViewModel to use for searching itineraries
+ * @param isNoResultFound: Boolean to indicate if no results were found
+ * @param navigation: Navigation object to use for navigation, i.e when an itinerary is clicked
+ */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchBar(modifier: Modifier = Modifier, onSearch: (String) -> Unit) {
-  TextField(
-      value = "",
-      onValueChange = { it -> onSearch(it) },
-      modifier = modifier,
-      placeholder = { Text("Search for an itinerary") },
-      leadingIcon = { Icon(Icons.Default.Search, contentDescription = "Search Icon") },
-      colors =
-          TextFieldDefaults.colors(
-              focusedContainerColor = Color.White,
-              focusedLeadingIconColor = Color.Gray,
-              focusedPlaceholderColor = Color.Gray,
-              focusedTextColor = Color.Black),
-      shape = MaterialTheme.shapes.small.copy(CornerSize(50)))
+fun SearchBar(
+    onBackClicked: () -> Unit = {},
+    onSearchActivated: (Boolean) -> Unit,
+    viewModel: HomeViewModel = viewModel(),
+    isNoResultFound: Boolean = false,
+    navigation: Navigation
+) {
+
+  var searchText by remember { mutableStateOf("") }
+  val items = viewModel.filteredItineraryList.value ?: listOf()
+  val focusManager = LocalFocusManager.current // Get access to the focus manager
+
+  // If the search bar is active (in focus or contains text), we'll consider it active.
+  var isActive by remember(searchText) { mutableStateOf(searchText.isNotEmpty()) }
+
+  androidx.compose.material3.SearchBar(
+      modifier = Modifier.fillMaxWidth().padding(14.dp).testTag("SearchItinerary"),
+      query = searchText,
+      onQueryChange = { newText ->
+        searchText = newText
+        viewModel.setSearchQuery(newText)
+        onSearchActivated(isActive)
+        isActive =
+            newText.isNotEmpty() ||
+                focusManager.equals(true) // Properly update the search query in the ViewModel
+      },
+      onSearch = { viewModel.setSearchQuery(searchText) },
+      active = isActive,
+      onActiveChange = { activeState ->
+        isActive = activeState
+        if (!activeState) { // When deactivating, clear the search text.
+          searchText = ""
+          viewModel.setSearchQuery("") // Reset search query
+        }
+      },
+      placeholder = {
+        Text(
+            "Search for an itinerary",
+            modifier = Modifier.width(200.dp),
+            fontFamily = FontFamily(Font(R.font.montserrat_regular)),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 0.15.sp,
+            color = md_theme_grey)
+      },
+      leadingIcon = {
+        if (isActive) {
+          androidx.compose.material.Icon(
+              modifier = Modifier.clickable { onBackClicked() },
+              imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = "Back")
+        } else {
+          androidx.compose.material.Icon(
+              imageVector = Icons.Default.Search, contentDescription = "Menu")
+        }
+      },
+      shape = MaterialTheme.shapes.small.copy(CornerSize(50)),
+      trailingIcon = {
+        if (isActive) {
+          androidx.compose.material.Icon(
+              modifier =
+                  Modifier.clickable {
+                    // Clear the text field
+                    searchText = ""
+                    viewModel.setSearchQuery("")
+                    // TODO: For now when clearing the text, it loses focus and exits the
+                    // "search mode"
+                    // we need to find a way to keep the search bar active even when the text is
+                    // cleared
+                  },
+              imageVector = Icons.Default.Close,
+              contentDescription = "Clear text field")
+        }
+      },
+  ) {
+    LaunchedEffect(searchText) { onSearchActivated(isActive) }
+    if (isNoResultFound) {
+      Text(
+          "No results found",
+          modifier = Modifier.padding(16.dp),
+          fontFamily = FontFamily(Font(R.font.montserrat_regular)),
+          fontSize = 16.sp,
+          fontWeight = FontWeight.Bold,
+          letterSpacing = 0.15.sp,
+          color = Color.Red)
+    }
+    // This displays the list of itineraries in the search results
+    LazyColumn {
+      val listToShow = if (isActive) items else viewModel.itineraryList.value ?: listOf()
+      items(listToShow) { itinerary ->
+        ItineraryItem(
+            itinerary = itinerary,
+            onItineraryClick = { id ->
+              // Hard coded for the moment
+              // TODO: Navigate to the itinerary details screen (2nd screen Figma)
+              val map = navigation.getTopLevelDestinations()[1].route
+              navigation.navController.navigate(map)
+            })
+      }
+    }
+  }
+}
+
+/**
+ * Displays an itinerary item when searching for itineraries
+ *
+ * @param itinerary: Itinerary object to display
+ * @param onItineraryClick: Function to call when the itinerary is clicked
+ */
+@Composable
+fun ItineraryItem(itinerary: Itinerary, onItineraryClick: (String) -> Unit) {
+  Row(
+      modifier =
+          Modifier.fillMaxWidth().clickable { onItineraryClick(itinerary.id) }.padding(16.dp)) {
+        Text(text = itinerary.title, style = MaterialTheme.typography.bodyMedium)
+      }
 }


### PR DESCRIPTION
This PR will allow the user to search for an itinerary based on its title.
1. For now, filters only by Itinerary Title.
2. In the "search view", it displays a list of `ItineraryItem` which is just a clickable text element
3. Clicking on an ItineraryItem will bring you to the map for now. Later it will also display a preview of the itinerary and as soon as you press start it will show the first few pins and the route (see Figma)
4. Clicking on the back button brings you back to the home page.
5. Clicking on the "X" button clears the text field and resets the search query to default. Only problem is that it loses focus when you clear the text, not so important for now but we should change this at some point.
6. Added a few comments here and there in `HomeScreen.kt`

It Should look like this : 
Empty Search Field          |  Filtered Itineraries
:----------------------------------------------:|:-------------------------:
<img width="293" alt="Screenshot 2024-04-09 at 14 43 32" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/9f3eac62-744a-403a-89a3-c12984234853">|<img width="311" alt="Screenshot 2024-04-09 at 14 44 14" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/430d8111-c8d7-429a-9f24-4a9e23449c56">
