### PR TITLE
Modified `DisplayItinerary` to have fixed size Itinerary boxes

### DIFF
--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
@@ -34,6 +33,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -126,7 +126,10 @@ fun SearchBar(
   var isActive by remember(searchText) { mutableStateOf(searchText.isNotEmpty()) }
 
   androidx.compose.material3.SearchBar(
-      modifier = Modifier.fillMaxWidth().padding(14.dp).testTag("SearchItinerary"),
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(horizontal = 30.dp, vertical = 5.dp)
+              .testTag("SearchItinerary"),
       query = searchText,
       onQueryChange = { newText ->
         searchText = newText
@@ -146,14 +149,17 @@ fun SearchBar(
         }
       },
       placeholder = {
-        Text(
-            "Search for an itinerary",
-            modifier = Modifier.width(200.dp),
-            fontFamily = FontFamily(Font(R.font.montserrat_regular)),
-            fontSize = 18.sp,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = 0.15.sp,
-            color = md_theme_grey)
+        Row {
+          Text(
+              "Search for an itinerary",
+              modifier = Modifier.weight(1f).padding(start = 10.dp),
+              textAlign = TextAlign.Center,
+              fontFamily = FontFamily(Font(R.font.montserrat_bold)),
+              fontSize = 21.sp,
+              fontWeight = FontWeight.Medium,
+              letterSpacing = 0.15.sp,
+              color = md_theme_grey)
+        }
       },
       leadingIcon = {
         if (isActive) {
@@ -205,8 +211,7 @@ fun SearchBar(
             onItineraryClick = { id ->
               // Hard coded for the moment
               // TODO: Navigate to the itinerary details screen (2nd screen Figma)
-              val map = navigation.getTopLevelDestinations()[1]
-              navigation.navigateTo(map)
+              // for now does nothing
             })
       }
     }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
@@ -50,8 +50,11 @@ fun DisplayItinerary(
 ) {
   // Number of additional itineraries not displayed
   val pinListString = fetchPinNames(itinerary)
+  // The height of the box that contains the itinerary, fixed
   val boxHeight = 200.dp
+  // The padding around the box
   val paddingAround = 15.dp
+  // The size of the user's avatar/profile picture
   val avatarSize = 20.dp
   Box(
       modifier =
@@ -100,7 +103,6 @@ fun DisplayItinerary(
               fontFamily = FontFamily(Font(R.font.montserrat_regular)),
               fontSize = 14.sp)
           Spacer(modifier = Modifier.height(30.dp).weight(1f))
-          // Spacer(modifier = Modifier.heightIn(6.dp).weight(1f))
           Text(
               text = pinListString,
               fontSize = 14.sp,

--- a/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -25,6 +24,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -50,10 +50,14 @@ fun DisplayItinerary(
 ) {
   // Number of additional itineraries not displayed
   val pinListString = fetchPinNames(itinerary)
+  val boxHeight = 200.dp
+  val paddingAround = 15.dp
+  val avatarSize = 20.dp
   Box(
       modifier =
           Modifier.fillMaxWidth()
-              .padding(vertical = 10.dp)
+              .padding(paddingAround)
+              .height(boxHeight)
               .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))
               .clickable { // When you click on an itinerary, it should bring you to the map
                 // overview with the selected itinerary highlighted and the first pinned places
@@ -68,7 +72,7 @@ fun DisplayItinerary(
                 model =
                     "https://blueprintdigital.com/wp-content/uploads/2014/11/stock-photo-happy-man-giving-okay-sign-portrait-on-white-background-141327337.jpg",
                 contentDescription = "User Avatar",
-                modifier = Modifier.size(20.dp).clip(CircleShape))
+                modifier = Modifier.size(avatarSize).clip(CircleShape))
             Spacer(modifier = Modifier.width(15.dp))
             Text(
                 text = itinerary.username,
@@ -95,11 +99,14 @@ fun DisplayItinerary(
               color = md_theme_orange, // This is the orange color
               fontFamily = FontFamily(Font(R.font.montserrat_regular)),
               fontSize = 14.sp)
-          Spacer(modifier = Modifier.height(20.dp))
-          Spacer(modifier = Modifier.heightIn(6.dp).weight(1f))
+          Spacer(modifier = Modifier.height(30.dp).weight(1f))
+          // Spacer(modifier = Modifier.heightIn(6.dp).weight(1f))
           Text(
-              text = "$pinListString",
+              text = pinListString,
               fontSize = 14.sp,
+              modifier = Modifier.fillMaxWidth(),
+              maxLines = 2,
+              overflow = "and more".let { TextOverflow.Ellipsis },
               fontFamily = FontFamily(Font(R.font.montserrat_medium)),
               color = md_theme_grey)
         }


### PR DESCRIPTION
This PR updates the UI to correctly show the itinerary when clicked on it on the map.
Itinerary boxes now have a fixed size. 
Changes are in 
1. Put the pinNames at the bottom of the box
2. Put Search for an itinerary in the middle of the search bar

This is how It looks like:

# Home Screen View
<img width="348" alt="Screenshot 2024-04-11 at 01 00 28" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/b20c7680-b6d3-4dd7-9462-3c19a4de41d7">


# Map Screen View
<img width="352" alt="Screenshot 2024-04-11 at 01 03 56" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/367df181-ce29-423c-b12c-116ddfdfc11c">

