### PR TITLE
Search Bar Filter Enhancements

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -233,6 +233,25 @@ class HomeTest {
   }
 
   @Test
+  fun clickOnDropDownMenu() {
+    every { mockItineraryRepository.getAllItineraries() } returns mockItineraries
+    every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.filteredItineraryList } returns MutableLiveData(mockItineraries)
+    // Setting up the test composition
+    composeTestRule.setContent { HomeScreen(navigation = mockNav, homeViewModel = mockViewModel) }
+    ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) {
+      searchBar {
+        assertIsDisplayed()
+        performClick()
+      }
+      composeTestRule
+          .onNodeWithTag("DropDownBox", useUnmergedTree = true)
+          .assertIsDisplayed()
+          .performClick()
+    }
+  }
+
+  @Test
   fun noResultWhenSearchingForInexistantItinerary() {
     every { mockItineraryRepository.getAllItineraries() } returns mockItineraries
     every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)

--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -80,9 +80,9 @@ class HomeTest {
     ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) {
       // Test the UI elements
       composeTestRule
-          .onNodeWithText("Search for an itinerary", useUnmergedTree = true)
+          .onNodeWithText("Find Itineraries", useUnmergedTree = true)
           .assertIsDisplayed()
-          .assertTextEquals("Search for an itinerary")
+          .assertTextEquals("Find Itineraries")
 
       itinerary {
         assertIsDisplayed()
@@ -216,7 +216,7 @@ class HomeTest {
         composeTestRule.onNodeWithTag("searchBarText", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("searchBarText", useUnmergedTree = true)
-            .assertTextEquals("Search for an itinerary")
+            .assertTextEquals("Find Itineraries")
         performClick()
         composeTestRule.waitForIdle()
         pressKey(84) // letter t, doesn't update the UI yet

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -76,7 +75,7 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
   Scaffold(
       topBar = {
         // Assuming a SearchBar composable is defined elsewhere
-        SearchBar(
+        SearchBarImplementation(
             onBackClicked = {
               // Navigate back to the home
               navigation.goBack()
@@ -98,7 +97,11 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
                     modifier = Modifier.testTag("DropDownFilter")) {
                       FilterType.entries.forEach { filterType ->
                         DropdownMenuItem(
-                            text = { Text(text = filterType.name.replace('_', ' ')) },
+                            text = {
+                              Text(
+                                  text = filterType.name.replace('_', ' '),
+                                  modifier = Modifier.testTag("FilterText"))
+                            },
                             onClick = {
                               homeViewModel.setSearchFilter(filterType)
                               showFilterDropdown = false
@@ -154,7 +157,7 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchBar(
+fun SearchBarImplementation(
     onBackClicked: () -> Unit = {},
     onSearchActivated: (Boolean) -> Unit,
     viewModel: HomeViewModel = viewModel(),
@@ -276,24 +279,4 @@ fun ItineraryItem(itinerary: Itinerary, onItineraryClick: (String) -> Unit) {
               .testTag("ItineraryItem")) {
         Text(text = itinerary.title, style = MaterialTheme.typography.bodyMedium)
       }
-}
-
-@Composable
-fun Test() {
-  val bool = true
-  // Test the HomeScreen
-  Box(modifier = Modifier.fillMaxSize()) {
-    // with this test, they superpose each other
-    Text(text = "La puta madre", color = Color.Red)
-    if (bool) {
-      Text(text = "Test bool", color = Color.White, modifier = Modifier.padding(5.dp))
-    }
-  }
-}
-
-@Preview
-@Composable
-fun HomePreview() {
-  // Preview the HomeScreen
-  Test()
 }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -1,12 +1,15 @@
 package com.example.triptracker.view.home
 
 import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
@@ -15,10 +18,13 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -35,6 +41,7 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -43,6 +50,7 @@ import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.NavigationBar
 import com.example.triptracker.view.theme.md_theme_grey
+import com.example.triptracker.viewmodel.FilterType
 import com.example.triptracker.viewmodel.HomeViewModel
 
 /**
@@ -54,9 +62,11 @@ import com.example.triptracker.viewmodel.HomeViewModel
 @Composable
 fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel()) {
   Log.d("HomeScreen", "Rendering HomeScreen")
+  val selectedFilterType by homeViewModel.selectedFilter.observeAsState(FilterType.TITLE)
 
   // Filtered list of itineraries based on search query
   val filteredList by homeViewModel.filteredItineraryList.observeAsState(initial = emptyList())
+  var showFilterDropdown by remember { mutableStateOf(false) }
   var isSearchActive by remember { mutableStateOf(false) }
   val isNoResultFound =
       remember(filteredList, isSearchActive) {
@@ -68,23 +78,55 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
         // Assuming a SearchBar composable is defined elsewhere
         SearchBar(
             onBackClicked = {
-              // Navigate back to the overview
-              val home = navigation.getTopLevelDestinations()[0].route
-              navigation.navController.navigate(home)
+              // Navigate back to the home
+              navigation.goBack()
             },
             viewModel = homeViewModel,
             onSearchActivated = { isActive -> isSearchActive = isActive },
             navigation = navigation,
+            selectedFilterType = selectedFilterType,
             isNoResultFound = isNoResultFound)
+        if (isSearchActive) {
+          Box(
+              modifier =
+                  Modifier.padding(270.dp, 27.dp, 30.dp, 220.dp)
+                      .width(200.dp)
+                      .testTag("DropDownBox")) {
+                DropdownMenu(
+                    expanded = showFilterDropdown,
+                    onDismissRequest = { showFilterDropdown = false },
+                    modifier = Modifier.testTag("DropDownFilter")) {
+                      FilterType.entries.forEach { filterType ->
+                        DropdownMenuItem(
+                            text = { Text(text = filterType.name.replace('_', ' ')) },
+                            onClick = {
+                              homeViewModel.setSearchFilter(filterType)
+                              showFilterDropdown = false
+                            })
+                      }
+                    }
+                Text(
+                    text = selectedFilterType.name,
+                    modifier =
+                        Modifier.clickable { showFilterDropdown = true }
+                            .background(
+                                MaterialTheme.colorScheme.surfaceVariant,
+                                shape = MaterialTheme.shapes.medium)
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                    fontFamily = FontFamily(Font(R.font.montserrat_semi_bold)),
+                    fontSize = 12.sp,
+                )
+              }
+        }
       },
       bottomBar = { NavigationBar(navigation) },
-      modifier = Modifier.testTag("HomeScreen")) { innerPadding ->
+      modifier = Modifier.fillMaxWidth().testTag("HomeScreen")) { innerPadding ->
         when (val itineraries = homeViewModel.itineraryList.value ?: emptyList()) {
           emptyList<Itinerary>() -> {
             Text(
                 text = "You do not have any itineraries yet.",
-                modifier = Modifier.padding(16.dp).testTag("NoItinerariesText"),
-                fontSize = 18.sp)
+                modifier = Modifier.padding(10.dp).testTag("NoItinerariesText"),
+                fontSize = 1.sp)
           }
           else -> {
             // will display the list of itineraries
@@ -116,102 +158,103 @@ fun SearchBar(
     onBackClicked: () -> Unit = {},
     onSearchActivated: (Boolean) -> Unit,
     viewModel: HomeViewModel = viewModel(),
+    selectedFilterType: FilterType,
     isNoResultFound: Boolean = false,
     navigation: Navigation
 ) {
-
   var searchText by remember { mutableStateOf("") }
   val items = viewModel.filteredItineraryList.value ?: listOf()
-  val focusManager = LocalFocusManager.current // Get access to the focus manager
-
+  val focusManager = LocalFocusManager.current
   // If the search bar is active (in focus or contains text), we'll consider it active.
-  var isActive by remember(searchText) { mutableStateOf(searchText.isNotEmpty()) }
+  var isActive by remember { mutableStateOf(false) }
 
-  androidx.compose.material3.SearchBar(
-      modifier =
-          Modifier.fillMaxWidth().padding(horizontal = 30.dp, vertical = 5.dp).testTag("searchBar"),
-      query = searchText,
-      onQueryChange = { newText ->
-        searchText = newText
-        viewModel.setSearchQuery(newText)
-        onSearchActivated(isActive)
-        isActive =
-            newText.isNotEmpty() ||
-                focusManager.equals(true) // Properly update the search query in the ViewModel
-      },
-      onSearch = { viewModel.setSearchQuery(searchText) },
-      active = isActive,
-      onActiveChange = { activeState ->
-        isActive = activeState
-        if (!activeState) { // When deactivating, clear the search text.
-          searchText = ""
-          viewModel.setSearchQuery("") // Reset search query
-        }
-      },
-      placeholder = {
+  Box(modifier = Modifier.fillMaxWidth()) {
+    SearchBar(
+        modifier =
+            Modifier.fillMaxWidth()
+                .padding(horizontal = 30.dp, vertical = 5.dp)
+                .testTag("searchBar"),
+        query = searchText,
+        onQueryChange = { newText ->
+          searchText = newText
+          viewModel.setSearchQuery(newText)
+          onSearchActivated(isActive)
+          isActive = newText.isNotEmpty() || focusManager.equals(true)
+        },
+        onSearch = {
+          viewModel.setSearchQuery(searchText)
+          isActive = false
+        },
+        leadingIcon = {
+          if (isActive) {
+            androidx.compose.material.Icon(
+                modifier = Modifier.clickable { onBackClicked() }.testTag("BackButton"),
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Back")
+          } else {
+            androidx.compose.material.Icon(
+                imageVector = Icons.Default.Search, contentDescription = "Menu")
+          }
+        },
+        trailingIcon = {
+          if (isActive) {
+            Icon(
+                modifier =
+                    Modifier.clickable {
+                          if (searchText.isEmpty()) {
+                            isActive = false // Deactivate the search bar if text is empty
+                          } else {
+                            searchText = "" // Clear the text but keep the search bar active
+                            viewModel.setSearchQuery(searchText) // Reset search query
+                          }
+                          onSearchActivated(isActive)
+                        }
+                        .testTag("ClearButton"),
+                imageVector = Icons.Default.Close,
+                contentDescription = "Clear text field")
+          }
+        },
+        active = isActive,
+        onActiveChange = { activeState ->
+          isActive = activeState
+          if (!activeState) { // When deactivating, clear the search text.
+            searchText = ""
+            viewModel.setSearchQuery("") // Reset search query
+          }
+        },
+        placeholder = {
+          Text(
+              "Find Itineraries",
+              modifier = Modifier.padding(start = 10.dp).testTag("searchBarText"),
+              textAlign = TextAlign.Center,
+              fontFamily = FontFamily(Font(R.font.montserrat_bold)),
+              fontSize = 21.sp,
+              fontWeight = FontWeight.Medium,
+              letterSpacing = 0.15.sp,
+              color = md_theme_grey)
+        },
+        shape = MaterialTheme.shapes.small.copy(CornerSize(50)),
+    ) {
+      LaunchedEffect(searchText) { onSearchActivated(isActive) }
+
+      if (isNoResultFound) {
         Text(
-            "Search for an itinerary",
-            modifier = Modifier.padding(start = 10.dp).testTag("searchBarText"),
-            textAlign = TextAlign.Center,
-            fontFamily = FontFamily(Font(R.font.montserrat_bold)),
-            fontSize = 21.sp,
-            fontWeight = FontWeight.Medium,
+            "No results found",
+            modifier = Modifier.padding(16.dp).testTag("NoResultsFound"),
+            fontFamily = FontFamily(Font(R.font.montserrat_regular)),
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Bold,
             letterSpacing = 0.15.sp,
-            color = md_theme_grey)
-      },
-      leadingIcon = {
-        if (isActive) {
-          androidx.compose.material.Icon(
-              modifier = Modifier.clickable { onBackClicked() }.testTag("BackButton"),
-              imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-              contentDescription = "Back")
-        } else {
-          androidx.compose.material.Icon(
-              imageVector = Icons.Default.Search, contentDescription = "Menu")
-        }
-      },
-      shape = MaterialTheme.shapes.small.copy(CornerSize(50)),
-      trailingIcon = {
-        if (isActive) {
-          androidx.compose.material.Icon(
-              modifier =
-                  Modifier.clickable {
-                        // Clear the text field
-                        searchText = ""
-                        viewModel.setSearchQuery("")
-                        // TODO: For now when clearing the text, it loses focus and exits the
-                        // "search mode"
-                        // we need to find a way to keep the search bar active even when the text is
-                        // cleared
-                      }
-                      .testTag("ClearButton"),
-              imageVector = Icons.Default.Close,
-              contentDescription = "Clear text field")
-        }
-      },
-  ) {
-    LaunchedEffect(searchText) { onSearchActivated(isActive) }
-    if (isNoResultFound) {
-      Text(
-          "No results found",
-          modifier = Modifier.padding(16.dp).testTag("NoResultsFound"),
-          fontFamily = FontFamily(Font(R.font.montserrat_regular)),
-          fontSize = 16.sp,
-          fontWeight = FontWeight.Bold,
-          letterSpacing = 0.15.sp,
-          color = Color.Red)
-    }
-    // This displays the list of itineraries in the search results
-    LazyColumn {
+            color = Color.Red)
+      }
+      // Itinerary items list
       val listToShow = if (isActive) items else viewModel.itineraryList.value ?: listOf()
-      items(listToShow) { itinerary ->
-        ItineraryItem(
-            itinerary = itinerary,
-            onItineraryClick = { id ->
-              // Hard coded for the moment
-              // TODO: Navigate to the itinerary details screen (2nd screen Figma)
-              // for now does nothing
-            })
+      LazyColumn {
+        items(listToShow) { itinerary ->
+          ItineraryItem(
+              itinerary = itinerary,
+              onItineraryClick = { /* TODO: Implement navigation to itinerary details */})
+        }
       }
     }
   }
@@ -233,4 +276,24 @@ fun ItineraryItem(itinerary: Itinerary, onItineraryClick: (String) -> Unit) {
               .testTag("ItineraryItem")) {
         Text(text = itinerary.title, style = MaterialTheme.typography.bodyMedium)
       }
+}
+
+@Composable
+fun Test() {
+  val bool = true
+  // Test the HomeScreen
+  Box(modifier = Modifier.fillMaxSize()) {
+    // with this test, they superpose each other
+    Text(text = "La puta madre", color = Color.Red)
+    if (bool) {
+      Text(text = "Test bool", color = Color.White, modifier = Modifier.padding(5.dp))
+    }
+  }
+}
+
+@Preview
+@Composable
+fun HomePreview() {
+  // Preview the HomeScreen
+  Test()
 }


### PR DESCRIPTION
This PR enables the user to search Itineraries not only by their titles but also by their usernames, flame counts, and even pin names !
To filter by flame counts, simply write your inequality (e.g <=2500) and it will give all itineraries which satisfy it.
The following changes were made : 
- Modification in `HomeViewModel.kt` :  filtering the Itinerary list given search query with a given Filter (_TITLE_, _USERNAME_, _FLAME_ or _PIN_)
- DropDownMenu with Text created in `HomeScreen.kt`
- A new test has been added, leading to 81% total coverage on the home package.
- To have a cleaner UI, change "Search for an itinerary" text to "Find itineraries"
- Fixed the bug when clicking clear text button brought user back to home view. Clicking it once when search query is not empty clears the text, clicking it again brings user back to Home Screen.

The UI now looks like this with some examples :
<img width="259" alt="Screenshot 2024-04-24 at 00 19 27" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/4f84a634-0673-4c6a-96e2-62d68f58bbf2">  <img width="258" alt="Screenshot 2024-04-24 at 00 19 36" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/7df50edb-28cc-4f92-bf11-04842a81565e">
--------------------
<img width="264" alt="Screenshot 2024-04-24 at 00 20 02" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/599a0f45-ce47-472f-a089-2c1768248f8f">
