### PR TITLE
Add Profile Edit Screen UI

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
@@ -4,12 +4,10 @@ import android.content.Context
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import com.example.triptracker.itinerary.MockItineraryList
-import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.map.MapOverview
 import com.example.triptracker.view.map.MapOverviewPreview
@@ -37,13 +35,11 @@ class MapOverviewTest : TestCase() {
 
   @RelaxedMockK private lateinit var mockViewModel: MapViewModel
   @RelaxedMockK private lateinit var mockNavigation: Navigation
-  @RelaxedMockK private lateinit var filteredPathList: MutableLiveData<Map<Itinerary, List<LatLng>>>
 
   @Before
   fun setUp() {
     mockViewModel = mockk(relaxed = true)
     mockNavigation = mockk(relaxed = true)
-    filteredPathList = mockk(relaxed = true)
   }
 
   @Test

--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -3,7 +3,7 @@ package com.example.triptracker.screens.home
 import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
-import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.material.icons.outlined.Place
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -97,6 +97,9 @@ class HomeTest {
     every { mockItineraryRepository.getAllItineraries() } returns mockItineraries
     every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
     every { mockViewModel.filteredItineraryList } returns MutableLiveData(null)
+    every { mockNav.getTopLevelDestinations()[1] } returns
+        TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps")
+
     // Setting up the test composition
     composeTestRule.setContent { HomeScreen(navigation = mockNav, homeViewModel = mockViewModel) }
     ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) {
@@ -165,6 +168,8 @@ class HomeTest {
     every { mockItineraryRepository.getAllItineraries() } returns mockItineraries
     every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
     every { mockViewModel.filteredItineraryList } returns MutableLiveData(null)
+    every { mockNav.getTopLevelDestinations()[1] } returns
+        TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps")
     // Setting up the test composition
     composeTestRule.setContent { HomeScreen(navigation = mockNav, homeViewModel = mockViewModel) }
     ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) { itinerary { performClick() } }

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
@@ -15,5 +15,5 @@ class UserProfileFollowersScreen(semanticsProvider: SemanticsNodeInteractionsPro
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
   val followersList: KNode = child { hasTestTag("FollowersList") }
   val removeButton: KNode = child { hasTestTag("RemoveButton") }
-  val followerProfile: KNode = child { hasTestTag("Friend") }
+  val followerProfile: KNode = child { hasTestTag("FriendProfile") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
@@ -15,5 +15,5 @@ class UserProfileFollowingScreen(semanticsProvider: SemanticsNodeInteractionsPro
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
   val removeButton: KNode = child { hasTestTag("RemoveButton") }
   val followingList: KNode = child { hasTestTag("FollowingList") }
-  val followingProfile: KNode = child { hasTestTag("Friend") }
+  val followingProfile: KNode = child { hasTestTag("FriendProfile") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/MockUserList.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/MockUserList.kt
@@ -1,35 +1,88 @@
 package com.example.triptracker.userProfile
 
 import com.example.triptracker.model.profile.UserProfile
-import java.util.Date
 
 class MockUserList {
   private val mockUser1 =
       UserProfile(
-          "1",
-          "Alice",
-          "Smith",
-          Date(2021, 1, 1),
-          "AliceS",
-          "stupid-image-url.com",
-          emptyList(),
+          "schifferlitheo@gmail.com",
+          "Theo",
+          "Schifferli",
+          "15-October-1946",
+          "Tete la malice",
+          "https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS5n-VN2sv2jYgbMF3kVQWkYZQtdlQzje7_-9SYrgFe6w6gUQmL",
+          listOf("cleorenaud38@gmail.com"),
           emptyList())
 
   private val mockUser2 =
-      UserProfile("2", "Bob", "Johnson", Date(2021, 1, 1), "BobJ", null, emptyList(), emptyList())
+      UserProfile(
+          "barghornjeremy@gmail.com",
+          "Jeremy",
+          "Barghorn",
+          "02-April-1939",
+          "GEHREMY",
+          "https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQKS6BRrbH2Pj2QZeMJX_EVsnQcO89myNj1cxHeh2KRLMiamzmL",
+          emptyList(),
+          emptyList())
 
   private val mockUser3 =
       UserProfile(
-          "3",
-          "Charlie",
-          "Brown",
-          Date(2021, 1, 1),
-          "CharlieB",
-          null,
-          listOf(mockUser1.mail, mockUser2.mail),
-          listOf(mockUser1.mail, mockUser2.mail))
+          "polfuentescam@gmail.com",
+          "Pol",
+          "Fuentes",
+          "27-September-1922",
+          "Polfuegoooo",
+          "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Maradona-Mundial_86_con_la_copa.JPG/1200px-Maradona-Mundial_86_con_la_copa.JPG",
+          emptyList(),
+          emptyList())
 
-  private val mockUsers = listOf(mockUser1, mockUser2, mockUser3)
+  private val mockUser4 =
+      UserProfile(
+          "leopold.galhaud@gmail.com",
+          "Leopold",
+          "Galhaud",
+          "20-December-2017",
+          "LeopoldinhoDoBrazil",
+          "https://encrypted-tbn0.gstatic.com/licensed-image?q=tbn:ANd9GcRviVquGNsci2DsyGkO0Wf8vlR9m_L0mT2jskinyr7YD6L3CKw_kO6Vdv0D7gFmmFena5SNPDdB0J9R6x8",
+          emptyList(),
+          emptyList())
+
+  private val mockUser5 =
+      UserProfile(
+          "misentaloic@gmail.com",
+          "Loic",
+          "Misenta",
+          "10-December-1936",
+          "Lomimi",
+          "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcRrfhlD13rGYJRmde04FRLNn2AT3uApwbvOcEfa5pAdMkQA3q8w",
+          emptyList(),
+          emptyList())
+
+  private val mockUser6 =
+      UserProfile(
+          "chaverotjrmy7@gmail.com",
+          "Jeremy",
+          "Chaverot",
+          "17-November-1948",
+          "JeremyyyTheTigerKing",
+          "https://cloudfront-us-east-1.images.arcpublishing.com/advancelocal/6AREHOEFLBGB3EHADZJ4AQCD4A.jpg",
+          emptyList(),
+          emptyList())
+
+  private val mockUser7 =
+      UserProfile(
+          mail = "cleorenaud38@gmail.com",
+          name = "Cleo",
+          surname = "Renaud",
+          birthdate = "08-February-2004",
+          username = "Cleoooo",
+          profileImageUrl =
+              "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+          followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+          following = emptyList())
+
+  private val mockUsers =
+      listOf(mockUser1, mockUser2, mockUser3, mockUser4, mockUser5, mockUser6, mockUser7)
 
   fun getUserProfiles(): List<UserProfile> {
     return mockUsers
@@ -37,6 +90,6 @@ class MockUserList {
 
   fun getNewMockUser(): UserProfile {
     return UserProfile(
-        "4", "David", "Doe", Date(2021, 1, 1), "DavidD", null, emptyList(), emptyList())
+        "4", "David", "Doe", "08-February-2021", "DavidD", null, emptyList(), emptyList())
   }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileListTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileListTest.kt
@@ -3,14 +3,13 @@ package com.example.triptracker.userProfile
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.model.profile.UserProfileList
-import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class UserProfileListTest {
-  private val date1 = Date(2021, 1, 1)
+  private val date1 = "08-February-2021"
 
   private val userProfileList1 = UserProfileList(listOf())
   private val userProfileList2 =
@@ -21,15 +20,19 @@ class UserProfileListTest {
                   name = "Alice",
                   surname = "Smith",
                   birthdate = date1,
-                  pseudo = "AliceS"),
+                  username = "AliceS"),
               UserProfile(
                   mail = "2",
                   name = "Bob",
                   surname = "Johnson",
                   birthdate = date1,
-                  pseudo = "BobJ"),
+                  username = "BobJ"),
               UserProfile(
-                  mail = "3", name = "Bob", surname = "Brown", birthdate = date1, pseudo = "BobB")))
+                  mail = "3",
+                  name = "Bob",
+                  surname = "Brown",
+                  birthdate = date1,
+                  username = "BobB")))
 
   private val userProfileList3 =
       UserProfileList(
@@ -39,19 +42,19 @@ class UserProfileListTest {
                   name = "Alice",
                   surname = "Smith",
                   birthdate = date1,
-                  pseudo = "AliceS"),
+                  username = "AliceS"),
               UserProfile(
                   mail = "5",
                   name = "Bob",
                   surname = "Johnson",
                   birthdate = date1,
-                  pseudo = "BobJ"),
+                  username = "BobJ"),
               UserProfile(
                   mail = "6",
                   name = "Charlie",
                   surname = "Brown",
                   birthdate = date1,
-                  pseudo = "CharlieB")))
+                  username = "CharlieB")))
 
   // TODO: complete this test
 

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileTest.kt
@@ -2,14 +2,13 @@ package com.example.triptracker.userProfile
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.model.profile.UserProfile
-import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class UserProfileTest {
-  private val date1 = Date(2021, 1, 1)
+  private val date1 = "08-February-2021"
 
   private val userProfile1 =
       UserProfile(
@@ -17,7 +16,7 @@ class UserProfileTest {
           name = "Alice",
           surname = "Smith",
           birthdate = date1,
-          pseudo = "AliceS",
+          username = "AliceS",
           profileImageUrl = "stupid-image-url.com",
           following = emptyList(),
           followers = emptyList())
@@ -28,7 +27,7 @@ class UserProfileTest {
           name = "Bob",
           surname = "Johnson",
           birthdate = date1,
-          pseudo = "BobJ",
+          username = "BobJ",
           profileImageUrl = null,
       )
 
@@ -36,7 +35,7 @@ class UserProfileTest {
       UserProfile(
           mail = "3",
           birthdate = date1,
-          pseudo = "CharlieB",
+          username = "CharlieB",
       )
 
   @Test
@@ -45,7 +44,7 @@ class UserProfileTest {
     assertEquals("Alice", userProfile1.name)
     assertEquals("Smith", userProfile1.surname)
     assertEquals(date1, userProfile1.birthdate)
-    assertEquals("AliceS", userProfile1.pseudo)
+    assertEquals("AliceS", userProfile1.username)
     assertEquals("stupid-image-url.com", userProfile1.profileImageUrl)
     assertEquals(emptyList<UserProfile>(), userProfile1.following)
     assertEquals(emptyList<UserProfile>(), userProfile1.followers)
@@ -57,7 +56,7 @@ class UserProfileTest {
     assertEquals("Bob", userProfile2.name)
     assertEquals("Johnson", userProfile2.surname)
     assertEquals(date1, userProfile2.birthdate)
-    assertEquals("BobJ", userProfile2.pseudo)
+    assertEquals("BobJ", userProfile2.username)
     assertEquals(null, userProfile2.profileImageUrl)
     assertEquals(emptyList<UserProfile>(), userProfile2.following)
     assertEquals(emptyList<UserProfile>(), userProfile2.followers)
@@ -69,7 +68,7 @@ class UserProfileTest {
     assertEquals("", userProfile3.name)
     assertEquals("", userProfile3.surname)
     assertEquals(date1, userProfile3.birthdate)
-    assertEquals("CharlieB", userProfile3.pseudo)
+    assertEquals("CharlieB", userProfile3.username)
     assertEquals(null, userProfile3.profileImageUrl)
     assertEquals(emptyList<UserProfile>(), userProfile3.following)
     assertEquals(emptyList<UserProfile>(), userProfile3.followers)

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileViewModelTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileViewModelTest.kt
@@ -131,7 +131,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val follower = mockList.getUserProfiles()[1]
 
-    mockViewModel.addFollowersInDb(user, follower)
+    mockViewModel.addFollower(user, follower)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }
@@ -148,7 +148,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val following = mockList.getUserProfiles()[1]
 
-    mockViewModel.addFollowingInDb(user, following)
+    mockViewModel.addFollower(following, user)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }
@@ -165,7 +165,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val follower = mockList.getUserProfiles()[1]
 
-    mockViewModel.removeFollowerInDb(user, follower)
+    mockViewModel.removeFollower(user, follower)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }
@@ -182,7 +182,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val following = mockList.getUserProfiles()[1]
 
-    mockViewModel.removeFollowingInDb(user, following)
+    mockViewModel.removeFollower(following, user)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -17,10 +17,12 @@ import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.Route
 import com.example.triptracker.view.home.HomeScreen
+import com.example.triptracker.view.map.DEFAULT_LOCATION
 import com.example.triptracker.view.map.MapOverview
 import com.example.triptracker.view.map.RecordScreen
 import com.example.triptracker.view.profile.UserProfileOverview
 import com.example.triptracker.view.theme.TripTrackerTheme
+import com.google.android.gms.maps.model.LatLng
 
 class MainActivity : ComponentActivity() {
 
@@ -59,6 +61,18 @@ class MainActivity : ComponentActivity() {
             composable(Route.LOGIN) { LoginScreen(navigation) }
             composable(Route.HOME) { HomeScreen(navigation) }
             composable(Route.MAPS) { MapOverview(context = context, navigation = navigation) }
+            composable(Route.MAPS + "/{lat}" + "/{lon}") { backStackEntry ->
+              val lat =
+                  backStackEntry.arguments?.getString("lat") ?: DEFAULT_LOCATION.latitude.toString()
+              val lon =
+                  backStackEntry.arguments?.getString("lon")
+                      ?: DEFAULT_LOCATION.longitude.toString()
+              MapOverview(
+                  context = context,
+                  navigation = navigation,
+                  startLocation = LatLng(lat.toDouble(), lon.toDouble()))
+            }
+
             composable(Route.RECORD) { RecordScreen(context, navigation) }
             composable(Route.PROFILE) { UserProfileOverview(navigation = navigation) }
           }

--- a/app/src/main/java/com/example/triptracker/model/location/popupState.kt
+++ b/app/src/main/java/com/example/triptracker/model/location/popupState.kt
@@ -1,0 +1,7 @@
+package com.example.triptracker.model.location
+
+enum class popupState {
+  DISPLAYITINERARY, // intermediary display with details
+  DISPLAYPIN, // firstDisplay it displays just the main overview of the path
+  PATHOVERLAY // display once the path is selected
+}

--- a/app/src/main/java/com/example/triptracker/model/profile/UserProfile.kt
+++ b/app/src/main/java/com/example/triptracker/model/profile/UserProfile.kt
@@ -1,7 +1,5 @@
 package com.example.triptracker.model.profile
 
-import java.util.Date
-
 /**
  * This data class represents a user's profile information.
  *
@@ -9,7 +7,7 @@ import java.util.Date
  * @property name : first name of the user. (Defaults: empty string)
  * @property surname : last name of the user. (Defaults: empty string)
  * @property birthdate : user's date of birth.
- * @property pseudo : nickname or pseudonym chosen by the user.
+ * @property username : nickname or pseudonym chosen by the user.
  * @property profileImageUrl : optional URL to the user's profile image. (Defaults: null)
  * @property followers : list of user's followers' email. (Defaults: empty list)
  * @property following : list of user's following's email. (Defaults: empty list)
@@ -18,8 +16,8 @@ data class UserProfile(
     val mail: String,
     val name: String = "",
     val surname: String = "",
-    val birthdate: Date,
-    val pseudo: String,
+    val birthdate: String = "",
+    val username: String = "",
     val profileImageUrl: String? = null,
     val followers: List<String> = emptyList(),
     val following: List<String> = emptyList()

--- a/app/src/main/java/com/example/triptracker/model/profile/UserProfileList.kt
+++ b/app/src/main/java/com/example/triptracker/model/profile/UserProfileList.kt
@@ -30,7 +30,7 @@ data class UserProfileList(private var userProfileList: List<UserProfile>) {
    * @param userProfile : user's profile to add
    */
   fun addUserProfile(userProfile: UserProfile) {
-    userProfileList = userProfileList + userProfile
+    this.userProfileList += userProfile
   }
 
   /**
@@ -43,7 +43,7 @@ data class UserProfileList(private var userProfileList: List<UserProfile>) {
     return userProfileList.filter {
       it.name.contains(task, ignoreCase = true) ||
           it.surname.contains(task, ignoreCase = true) ||
-          it.pseudo.contains(task, ignoreCase = true)
+          it.username.contains(task, ignoreCase = true)
     }
   }
 

--- a/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
@@ -5,7 +5,6 @@ import com.example.triptracker.model.profile.UserProfile
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.firestore
-import java.util.Date
 
 /**
  * Repository for the UserProfile class This class is responsible for handling the data operations
@@ -67,7 +66,7 @@ open class UserProfileRepository {
                     document.id,
                     document.data?.get("name") as String,
                     document.data?.get("surname") as String,
-                    document.data?.get("birthdate") as Date,
+                    document.data?.get("birthdate") as String,
                     document.data?.get("pseudo") as String,
                     document.data?.get("profileImageUrl") as String)
           } else {
@@ -91,7 +90,7 @@ open class UserProfileRepository {
               document.id,
               document.data["name"] as String,
               document.data["surname"] as String,
-              document.data["birthdate"] as Date,
+              document.data["birthdate"] as String,
               document.data["pseudo"] as String,
               document.data["profileImageUrl"] as String)
 

--- a/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
@@ -1,18 +1,38 @@
 package com.example.triptracker.view
 
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.triptracker.R
+import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
+import com.example.triptracker.view.theme.md_theme_orange
 
+/**
+ * A top bar for the navigation.
+ *
+ * @param modifier Modifier to be applied to the layout.
+ * @param title The title of the top bar.
+ * @param canNavigateBack Whether the top bar should have a back button.
+ * @param navigateUp The action to perform when the back button is clicked.
+ * @param actions The actions to display on the top bar (like a save button).
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NavTopBar(
@@ -38,4 +58,28 @@ fun NavTopBar(
   } else {
     TopAppBar(title = { Text(text = title) }, actions = { actions() }, modifier = modifier)
   }
+}
+
+/** Preview for the NavTopBar to have an example. */
+@Preview
+@Composable
+fun NavTopBarPreview() {
+  NavTopBar(
+      title = stringResource(id = R.string.app_name),
+      canNavigateBack = true,
+      navigateUp = {},
+      actions = {
+        FilledTonalButton(
+            onClick = {},
+            colors = ButtonDefaults.filledTonalButtonColors(containerColor = md_theme_orange),
+            modifier = Modifier.width(90.dp).height(30.dp),
+        ) {
+          Text(
+              text = "Save",
+              fontSize = 14.sp,
+              fontFamily = Montserrat,
+              fontWeight = FontWeight.SemiBold,
+              color = Color.White)
+        }
+      })
 }

--- a/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
@@ -1,29 +1,5 @@
 package com.example.triptracker.view
 
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.example.triptracker.R
-import com.example.triptracker.view.theme.Montserrat
-import com.example.triptracker.view.theme.md_theme_grey
-import com.example.triptracker.view.theme.md_theme_orange
-
 /**
  * A top bar for the navigation.
  *
@@ -33,15 +9,15 @@ import com.example.triptracker.view.theme.md_theme_orange
  * @param navigateUp The action to perform when the back button is clicked.
  * @param actions The actions to display on the top bar (like a save button).
  */
-//@OptIn(ExperimentalMaterial3Api::class)
-//@Composable
-//fun NavTopBar(
+// @OptIn(ExperimentalMaterial3Api::class)
+// @Composable
+// fun NavTopBar(
 //    modifier: Modifier = Modifier,
 //    title: String,
 //    canNavigateBack: Boolean,
 //    navigateUp: () -> Unit = {},
 //    actions: @Composable () -> Unit = {}
-//) {
+// ) {
 //  if (canNavigateBack) {
 //    TopAppBar(
 //        title = { Text(text = title) },
@@ -58,12 +34,12 @@ import com.example.triptracker.view.theme.md_theme_orange
 //  } else {
 //    TopAppBar(title = { Text(text = title) }, actions = { actions() }, modifier = modifier)
 //  }
-//}
+// }
 
 /** Preview for the NavTopBar to have an example. */
-//@Preview
-//@Composable
-//fun NavTopBarPreview() {
+// @Preview
+// @Composable
+// fun NavTopBarPreview() {
 //  NavTopBar(
 //      title = stringResource(id = R.string.app_name),
 //      canNavigateBack = true,
@@ -82,4 +58,4 @@ import com.example.triptracker.view.theme.md_theme_orange
 //              color = Color.White)
 //        }
 //      })
-//}
+// }

--- a/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
@@ -1,0 +1,41 @@
+package com.example.triptracker.view
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.example.triptracker.R
+import com.example.triptracker.view.theme.md_theme_grey
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NavTopBar(
+    modifier: Modifier = Modifier,
+    title: String,
+    canNavigateBack: Boolean,
+    navigateUp: () -> Unit = {},
+    actions: @Composable () -> Unit = {}
+) {
+  if (canNavigateBack) {
+    TopAppBar(
+        title = { Text(text = title) },
+        actions = { actions() },
+        navigationIcon = {
+          IconButton(onClick = navigateUp) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "Back",
+                tint = md_theme_grey)
+          }
+        },
+        modifier = modifier)
+  } else {
+    TopAppBar(title = { Text(text = title) }, actions = { actions() }, modifier = modifier)
+  }
+}

--- a/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/TopNavigationBar.kt
@@ -33,53 +33,53 @@ import com.example.triptracker.view.theme.md_theme_orange
  * @param navigateUp The action to perform when the back button is clicked.
  * @param actions The actions to display on the top bar (like a save button).
  */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun NavTopBar(
-    modifier: Modifier = Modifier,
-    title: String,
-    canNavigateBack: Boolean,
-    navigateUp: () -> Unit = {},
-    actions: @Composable () -> Unit = {}
-) {
-  if (canNavigateBack) {
-    TopAppBar(
-        title = { Text(text = title) },
-        actions = { actions() },
-        navigationIcon = {
-          IconButton(onClick = navigateUp) {
-            Icon(
-                imageVector = Icons.Default.ArrowBack,
-                contentDescription = "Back",
-                tint = md_theme_grey)
-          }
-        },
-        modifier = modifier)
-  } else {
-    TopAppBar(title = { Text(text = title) }, actions = { actions() }, modifier = modifier)
-  }
-}
+//@OptIn(ExperimentalMaterial3Api::class)
+//@Composable
+//fun NavTopBar(
+//    modifier: Modifier = Modifier,
+//    title: String,
+//    canNavigateBack: Boolean,
+//    navigateUp: () -> Unit = {},
+//    actions: @Composable () -> Unit = {}
+//) {
+//  if (canNavigateBack) {
+//    TopAppBar(
+//        title = { Text(text = title) },
+//        actions = { actions() },
+//        navigationIcon = {
+//          IconButton(onClick = navigateUp) {
+//            Icon(
+//                imageVector = Icons.Default.ArrowBack,
+//                contentDescription = "Back",
+//                tint = md_theme_grey)
+//          }
+//        },
+//        modifier = modifier)
+//  } else {
+//    TopAppBar(title = { Text(text = title) }, actions = { actions() }, modifier = modifier)
+//  }
+//}
 
 /** Preview for the NavTopBar to have an example. */
-@Preview
-@Composable
-fun NavTopBarPreview() {
-  NavTopBar(
-      title = stringResource(id = R.string.app_name),
-      canNavigateBack = true,
-      navigateUp = {},
-      actions = {
-        FilledTonalButton(
-            onClick = {},
-            colors = ButtonDefaults.filledTonalButtonColors(containerColor = md_theme_orange),
-            modifier = Modifier.width(90.dp).height(30.dp),
-        ) {
-          Text(
-              text = "Save",
-              fontSize = 14.sp,
-              fontFamily = Montserrat,
-              fontWeight = FontWeight.SemiBold,
-              color = Color.White)
-        }
-      })
-}
+//@Preview
+//@Composable
+//fun NavTopBarPreview() {
+//  NavTopBar(
+//      title = stringResource(id = R.string.app_name),
+//      canNavigateBack = true,
+//      navigateUp = {},
+//      actions = {
+//        FilledTonalButton(
+//            onClick = {},
+//            colors = ButtonDefaults.filledTonalButtonColors(containerColor = md_theme_orange),
+//            modifier = Modifier.width(90.dp).height(30.dp),
+//        ) {
+//          Text(
+//              text = "Save",
+//              fontSize = 14.sp,
+//              fontFamily = Montserrat,
+//              fontWeight = FontWeight.SemiBold,
+//              color = Color.White)
+//        }
+//      })
+//}

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
@@ -48,6 +47,7 @@ import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.NavigationBar
+import com.example.triptracker.view.Route
 import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.viewmodel.FilterType
 import com.example.triptracker.viewmodel.HomeViewModel
@@ -138,7 +138,15 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
                 contentPadding = PaddingValues(16.dp)) {
                   items(itineraries) { itinerary ->
                     Log.d("ItineraryToDisplay", "Displaying itinerary: $itinerary")
-                    DisplayItinerary(itinerary = itinerary, navigation = navigation)
+                    DisplayItinerary(
+                        itinerary = itinerary,
+                        navigation = navigation,
+                        onClick = {
+                          navigation.navigateTo(navigation.getTopLevelDestinations()[1])
+                          navigation.navController.navigate(
+                              Route.MAPS +
+                                  "/${itinerary.location.latitude}/${itinerary.location.longitude}")
+                        })
                   }
                 }
           }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
@@ -45,11 +45,7 @@ import com.example.triptracker.view.theme.md_theme_orange
  * @param pinNamesMap: Map of itinerary ID to list of pin names
  */
 @Composable
-fun DisplayItinerary(
-    itinerary: Itinerary,
-    navigation: Navigation,
-    // onClick: () -> Unit, TODO : Uncomment this line when needed
-) {
+fun DisplayItinerary(itinerary: Itinerary, navigation: Navigation, onClick: () -> Unit) {
   // Number of additional itineraries not displayed
   val pinListString = fetchPinNames(itinerary)
   // The height of the box that contains the itinerary, fixed
@@ -66,8 +62,7 @@ fun DisplayItinerary(
               .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))
               .clickable { // When you click on an itinerary, it should bring you to the map
                 // overview with the selected itinerary highlighted and the first pinned places
-                // TODO : when changing Top Level Destination, the navbar should be updated to
-                // highlight the correct tab.
+                onClick()
                 // TODO : Would call DisplayItineraryInMap or sth similar later on
                 // onClick()
               }

--- a/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
@@ -1,15 +1,21 @@
 package com.example.triptracker.view.profile
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -20,19 +26,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
 import com.example.triptracker.R
 import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.view.theme.md_theme_dark_gray
+import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
-import com.example.triptracker.view.theme.md_theme_light_secondaryContainer
+import com.example.triptracker.view.theme.md_theme_light_onPrimary
+import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.UserProfileViewModel
 
 /**
@@ -48,68 +61,131 @@ fun FriendListView(
     userProfile: UserProfile,
     followers: Boolean,
 ) {
+  // TODO: Remove this hardcoded list of friends
   val friends =
-      if (followers) {
-        userProfile.followers.map { mail -> userProfileViewModel.getUserProfileFromDb(mail)!! }
-      } else {
-        userProfile.following.map { mail -> userProfileViewModel.getUserProfileFromDb(mail)!! }
-      }
+      listOf(
+          UserProfile(
+              "schifferlitheo@gmail.com",
+              "Theo",
+              "Schifferli",
+              "15-October-1946",
+              "Tete la malice",
+              "https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS5n-VN2sv2jYgbMF3kVQWkYZQtdlQzje7_-9SYrgFe6w6gUQmL",
+              listOf("cleorenaud38@gmail.com"),
+              emptyList()))
 
   // Display the list of user's profiles
   LazyColumn(
-      modifier = Modifier.fillMaxWidth().padding(15.dp).testTag("FriendListScreen"),
-  ) {
-    items(friends) { friend ->
-      // Display the user's profile
-      Row(
-          modifier = Modifier.height(70.dp).fillMaxWidth(),
-      ) {
-        Column(modifier = Modifier.fillMaxHeight()) {
-          Text(
-              text = friend.pseudo,
-              style =
-                  TextStyle(
-                      fontSize = 20.sp,
-                      lineHeight = 16.sp,
-                      fontFamily = FontFamily(Font(R.font.montserrat)),
-                      fontWeight = FontWeight(700),
-                      color = Color.Black,
-                      textAlign = TextAlign.Right,
-                      letterSpacing = 0.5.sp),
-          )
-          Row(
-              // modifier = Modifier.fillMaxWidth(),
-              verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = friend.name,
-                    style = AppTypography.secondaryTitleStyle,
-                )
-                Spacer(modifier = Modifier.width(2.dp))
-                Text(
-                    text = friend.surname,
-                    style = AppTypography.secondaryTitleStyle,
-                )
-              }
-        }
-        Column(
-            modifier = Modifier.fillMaxWidth().testTag("Friend"),
-            horizontalAlignment = Alignment.End) {
-              if (followers) {
-                // Display the remove follower button
-                RemoveFriendButton(
-                    remove = { userProfileViewModel.removeFollowerInDb(userProfile, friend) },
-                    undoRemove = { userProfileViewModel.addFollowersInDb(userProfile, friend) },
-                    followers = true)
-              } else {
-                RemoveFriendButton(
-                    remove = { userProfileViewModel.removeFollowingInDb(userProfile, friend) },
-                    undoRemove = { userProfileViewModel.addFollowingInDb(userProfile, friend) },
-                    followers = false)
-              }
+      modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(15.dp).testTag("FriendListScreen"),
+      verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        if (friends.isEmpty()) {
+          item {
+            Text(
+                text = if (followers) "No followers" else "Not following anyone",
+                style =
+                    TextStyle(
+                        fontSize = 20.sp,
+                        lineHeight = 16.sp,
+                        fontFamily = FontFamily(Font(R.font.montserrat)),
+                        fontWeight = FontWeight(700),
+                        color = Color.Black,
+                        textAlign = TextAlign.Center,
+                        letterSpacing = 0.5.sp),
+                modifier = Modifier.fillMaxWidth().padding(10.dp))
+          }
+        } else {
+          items(friends) { friend ->
+            if (friend != null) {
+              // Display the user's profile
+              Box(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .height(105.dp)
+                          .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp))
+                          .testTag("FriendProfile"),
+                  contentAlignment = Alignment.Center) {
+                    Row(
+                        modifier = Modifier.fillMaxHeight().padding(start = 20.dp, end = 20.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
+                          // Image painter for loading from a URL
+                          val imagePainter =
+                              rememberAsyncImagePainter(model = friend.profileImageUrl)
+
+                          Image(
+                              painter = imagePainter,
+                              contentDescription = "${userProfile.username}'s profile picture",
+                              contentScale = ContentScale.Crop,
+                              modifier =
+                                  Modifier.size(62.dp)
+                                      .clip(RoundedCornerShape(50))
+                                      .align(Alignment.CenterVertically))
+                          Column(
+                              modifier = Modifier.fillMaxHeight().padding(start = 15.dp),
+                              verticalArrangement = Arrangement.Center) {
+                                Text(
+                                    text = friend.username,
+                                    style =
+                                        TextStyle(
+                                            fontSize = 16.sp,
+                                            lineHeight = 16.sp,
+                                            fontFamily = FontFamily(Font(R.font.montserrat)),
+                                            fontWeight = FontWeight(600),
+                                            color = Color.White,
+                                            textAlign = TextAlign.Left,
+                                            letterSpacing = 0.5.sp),
+                                    overflow = TextOverflow.Ellipsis,
+                                    maxLines = 1)
+                                Row(
+                                    // modifier = Modifier.fillMaxWidth(),
+                                    //                              verticalAlignment =
+                                    // Alignment.CenterVertically
+                                    ) {
+                                      Text(
+                                          text = "${friend.name} ${friend.surname}",
+                                          style =
+                                              TextStyle(
+                                                  fontSize = 14.sp,
+                                                  lineHeight = 16.sp,
+                                                  fontFamily = FontFamily(Font(R.font.montserrat)),
+                                                  fontWeight = FontWeight(600),
+                                                  color = md_theme_dark_gray,
+                                                  textAlign = TextAlign.Left,
+                                                  letterSpacing = 0.5.sp),
+                                          overflow = TextOverflow.Ellipsis,
+                                          maxLines = 1)
+                                    }
+                              }
+                          Column(
+                              modifier = Modifier.fillMaxWidth().width(95.dp),
+                              horizontalAlignment = Alignment.End,
+                          ) {
+                            if (followers) {
+                              // Display the remove follower button
+                              RemoveFriendButton(
+                                  remove = {
+                                    userProfileViewModel.removeFollower(userProfile, friend)
+                                  },
+                                  undoRemove = {
+                                    userProfileViewModel.addFollower(userProfile, friend)
+                                  },
+                                  followers = true)
+                            } else {
+                              RemoveFriendButton(
+                                  remove = {
+                                    userProfileViewModel.removeFollower(friend, userProfile)
+                                  },
+                                  undoRemove = {
+                                    userProfileViewModel.addFollower(friend, userProfile)
+                                  },
+                                  followers = false)
+                            }
+                          }
+                        }
+                  }
             }
+          }
+        }
       }
-    }
-  }
 }
 
 /** This composable function displays a button to remove a follower. */
@@ -133,17 +209,18 @@ fun RemoveFriendButton(remove: () -> Unit, undoRemove: () -> Unit, followers: Bo
       colors =
           if (!isRemoved) {
             ButtonDefaults.buttonColors(
-                containerColor = md_theme_light_dark,
-                contentColor = md_theme_light_secondaryContainer)
+                containerColor = md_theme_orange, contentColor = md_theme_light_onPrimary)
           } else {
             ButtonDefaults.buttonColors(
-                containerColor = md_theme_light_secondaryContainer,
-                contentColor = md_theme_light_dark)
+                containerColor = md_theme_grey, contentColor = md_theme_light_onPrimary)
           },
-      modifier =
-          Modifier.height(40.dp)
-              .width(120.dp)
-              .testTag("RemoveButton")) { // .testTag(if (isRemoved) { "RemoveButton" } else {
+      modifier = Modifier.height(40.dp).width(95.dp).testTag("RemoveButton"),
+      contentPadding =
+          PaddingValues( // Reduce the padding around the text
+              start = 2.dp,
+              top = 4.dp,
+              end = 2.dp,
+              bottom = 4.dp)) { // .testTag(if (isRemoved) { "RemoveButton" } else {
         // "UndoButton" })) {
         Text(
             text =
@@ -152,44 +229,16 @@ fun RemoveFriendButton(remove: () -> Unit, undoRemove: () -> Unit, followers: Bo
                 if (!followers && isRemoved) "Follow" // when displaying removed following
                 else if (!followers && !isRemoved) "Following" // when displaying following
                 else if (followers && isRemoved) "Undo" // when displaying removed followers
-                else "Remove" // when displaying followers
-            )
+                else "Remove", // when displaying followers
+            modifier = Modifier.fillMaxWidth(),
+            style =
+                TextStyle(
+                    fontSize = 12.sp,
+                    lineHeight = 12.sp,
+                    fontFamily = FontFamily(Font(R.font.montserrat)),
+                    fontWeight = FontWeight(500),
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    letterSpacing = 0.5.sp))
       }
 }
-
-// @Preview
-// @Composable
-// fun FriendListViewPreview() {
-//    val mockUser1 =
-//        UserProfile(
-//            "1",
-//            "Alice",
-//            "Smith",
-//            Date(2021, 1, 1),
-//            "AliceS",
-//            "stupid-image-url.com",
-//            emptyList(),
-//            emptyList()
-//        )
-//
-//    val mockUser2 =
-//        UserProfile("2", "Bob", "Johnson", Date(2021, 1, 1), "BobJ", null, emptyList(),
-// emptyList())
-//
-//    val mockUser3 =
-//        UserProfile(
-//            "3",
-//            "Charlie",
-//            "Brown",
-//            Date(2021, 1, 1),
-//            "CharlieB",
-//            null,
-//            listOf(mockUser1, mockUser2),
-//            listOf(mockUser1, mockUser2)
-//        )
-//
-//    val mockUsers = listOf(mockUser1, mockUser2, mockUser3)
-//
-//    FriendListView(userProfileViewModel = UserProfileViewModel(), userProfile = mockUser3,
-// followers = true)
-// }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -7,11 +7,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.Text
@@ -47,6 +47,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.NavTopBar
 import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.NavigationBar
 import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
@@ -129,202 +130,73 @@ fun UserProfileEditScreen(navigation: Navigation) {
             title = "Edit Profile",
             canNavigateBack = true,
             navigateUp = { navigation.goBack() },
-            actions = {
-              SaveButton(
-                  canSave =
-                      !isNameEmpty && !isSurnameEmpty && !isBirthdateEmpty && !isUsernameEmpty,
-                  action = {
-                    updateProfile(profile, name, surname, mail, birthdate, username, imageUrl)
-                  })
-            })
+            actions = {})
       },
+      bottomBar = { NavigationBar(navigation) },
       modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
         Box(
             modifier =
-                Modifier.fillMaxHeight()
+                Modifier.fillMaxHeight().padding(innerPadding)
+                    .padding(top = 35.dp, bottom = 35.dp, start = 25.dp, end = 25.dp)
                     .fillMaxWidth()
-                    .padding(innerPadding)
-                    .fillMaxSize()
-                    .background(md_theme_light_dark),
+                    .background(md_theme_light_dark, shape = RoundedCornerShape(20.dp)),
             contentAlignment = Alignment.TopCenter) {
               Column(
                   horizontalAlignment = Alignment.Start,
                   verticalArrangement = Arrangement.SpaceEvenly) {
+                    Spacer(modifier = Modifier.height(25.dp))
+                    ProfileEditTextField(
+                        "Username",
+                        username,
+                        {
+                          username = it
+                          isUsernameEmpty = it.isEmpty()
+                        },
+                        isUsernameEmpty)
+                    Spacer(modifier = Modifier.height(15.dp))
+                    ProfileEditTextField(
+                        "Name",
+                        name,
+                        {
+                          name = it
+                          isNameEmpty = it.isEmpty()
+                        },
+                        isNameEmpty)
+                    Spacer(modifier = Modifier.height(15.dp))
+                    ProfileEditTextField(
+                        "Surname",
+                        surname,
+                        {
+                          surname = it
+                          isSurnameEmpty = it.isEmpty()
+                        },
+                        isSurnameEmpty)
+                    Spacer(modifier = Modifier.height(15.dp))
+                    ProfileEditTextField(
+                        "Mail",
+                        mail,
+                        {
+                          mail = it
+                          isMailEmpty = it.isEmpty()
+                        },
+                        isMailEmpty)
+                    Spacer(modifier = Modifier.height(15.dp))
+
+                    val isOpen = remember { mutableStateOf(false) }
                     Text(
-                        text = "Change your information below",
+                        text = "Date of birth",
                         fontSize = 14.sp,
                         fontFamily = Montserrat,
                         fontWeight = FontWeight.Normal,
                         color = md_theme_grey,
-                        modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
-                    )
-
-                    Spacer(modifier = Modifier.height(10.dp))
-                    OutlinedTextField(
-                        value = name,
-                        onValueChange = {
-                          name = it
-                          isNameEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Name",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    OutlinedTextField(
-                        value = surname,
-                        onValueChange = {
-                          surname = it
-                          isSurnameEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Surname",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    OutlinedTextField(
-                        value = mail,
-                        onValueChange = {
-                          mail = it
-                          isMailEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Mail",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    OutlinedTextField(
-                        value = username,
-                        onValueChange = {
-                          username = it
-                          isUsernameEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Username",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    val isOpen = remember { mutableStateOf(false) }
-
+                        modifier = Modifier.padding(start = 30.dp, end = 30.dp))
                     Row(verticalAlignment = Alignment.CenterVertically) {
                       OutlinedTextField(
                           readOnly = true,
                           value = birthdate.format(DateTimeFormatter.ISO_DATE),
-                          label = {
-                            Text(
-                                text = "Date of birth",
-                                fontSize = 14.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal,
-                                color = Color.White)
-                          },
+                          label = {},
                           onValueChange = {},
-                          modifier =
-                              Modifier.padding(top = 5.dp, bottom = 5.dp, start = 30.dp).weight(1f),
+                          modifier = Modifier.padding(bottom = 5.dp, start = 30.dp).weight(1f),
                           textStyle =
                               TextStyle(
                                   color = Color.White,
@@ -351,7 +223,7 @@ fun UserProfileEditScreen(navigation: Navigation) {
                             Icon(
                                 imageVector = Icons.Default.CalendarMonth,
                                 contentDescription = "Calendar",
-                                tint = Color.White)
+                                tint = Color.Gray)
                           }
                     }
 
@@ -369,9 +241,70 @@ fun UserProfileEditScreen(navigation: Navigation) {
                             isOpen.value = false // close dialog
                           })
                     }
+                    Spacer(modifier = Modifier.height(50.dp))
+                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                      SaveButton(
+                          canSave =
+                              !isNameEmpty &&
+                                  !isSurnameEmpty &&
+                                  !isBirthdateEmpty &&
+                                  !isUsernameEmpty,
+                          action = {
+                            updateProfile(
+                                profile, name, surname, mail, birthdate, username, imageUrl)
+                          })
+                    }
                   }
             }
       }
+}
+
+/**
+ * This composable function displays a profile edit text field.
+ *
+ * @param label : label of the text field.
+ * @param value : value of the text field.
+ * @param onValueChange : function to be called when the value of the text field changes.
+ * @param isEmpty : boolean indicating if the text field is empty.
+ * @param modifier : modifier for the text field.
+ */
+@Composable
+fun ProfileEditTextField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    isEmpty: Boolean,
+    modifier: Modifier =
+        Modifier.fillMaxWidth(1f).padding(bottom = 5.dp, start = 30.dp, end = 30.dp)
+) {
+  Text(
+      text = label,
+      fontSize = 14.sp,
+      fontFamily = Montserrat,
+      fontWeight = FontWeight.Normal,
+      color = md_theme_grey,
+      modifier = Modifier.padding(start = 30.dp, end = 30.dp),
+  )
+  OutlinedTextField(
+      value = value,
+      onValueChange = { onValueChange(it) },
+      label = {},
+      modifier = modifier,
+      textStyle =
+          TextStyle(
+              color = Color.White,
+              fontSize = 16.sp,
+              fontFamily = Montserrat,
+              fontWeight = FontWeight.Normal),
+      colors =
+          OutlinedTextFieldDefaults.colors(
+              unfocusedTextColor = Color.White,
+              unfocusedBorderColor = if (isEmpty) md_theme_light_error else md_theme_grey,
+              unfocusedLabelColor = if (isEmpty) md_theme_light_error else md_theme_grey,
+              cursorColor = Color.White,
+              focusedBorderColor = if (isEmpty) md_theme_light_error else md_theme_grey,
+              focusedLabelColor = Color.White,
+          ))
 }
 
 /**
@@ -417,7 +350,7 @@ fun SaveButton(canSave: Boolean = true, action: () -> Unit = {}) {
               containerColor = md_theme_orange, contentColor = Color.White)) {
         Text(
             text = "Save",
-            fontSize = 18.sp,
+            fontSize = 15.sp,
             fontFamily = Montserrat,
             fontWeight = FontWeight.SemiBold,
             color = Color.White)

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -135,9 +135,9 @@ fun UserProfileEditScreen(navigation: Navigation) {
 
   /* Mutable state variable that holds the username of the user profile */
   var username by remember {
-    mutableStateOf(profile.pseudo)
-  } // TODO: change when pseudo ---> username
-  var isUsernameEmpty by remember { mutableStateOf(profile.pseudo.isEmpty()) }
+    mutableStateOf(profile.username)
+  }
+  var isUsernameEmpty by remember { mutableStateOf(profile.username.isEmpty()) }
 
   /* Mutable state variable that holds the image url of the user profile */
   var imageUrl by remember { mutableStateOf(profile.profileImageUrl) }
@@ -517,10 +517,10 @@ fun InsertPicture(
 }
 
 /** This function previews the UserProfileEditScreen. */
-@Preview
-@Composable
-fun UserProfileEditScreenPreview() {
-  val navController = rememberNavController()
-  val navigation = remember(navController) { Navigation(navController) }
-  UserProfileEditScreen(navigation)
-}
+//@Preview
+//@Composable
+//fun UserProfileEditScreenPreview() {
+//  val navController = rememberNavController()
+//  val navigation = remember(navController) { Navigation(navController) }
+//  UserProfileEditScreen(navigation)
+//}

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -11,16 +11,24 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -39,136 +47,410 @@ import androidx.navigation.compose.rememberNavController
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.NavTopBar
 import com.example.triptracker.view.Navigation
-import com.example.triptracker.view.NavigationBar
 import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
 import com.example.triptracker.view.theme.md_theme_light_error
 import com.example.triptracker.view.theme.md_theme_orange
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Date
 
-@Composable
-fun UserProfileEditScreen(navigation: Navigation) {
-    val profile = // TODO: replace with actual user profile
-        UserProfile(
-            "mail", "name", "surname", Date(), "pseudo", "profileImageUrl", listOf(), listOf())
-
-    var mail by remember { mutableStateOf("") }
-    var isMailEmpty by remember { mutableStateOf(false) }
-
-    var name by remember { mutableStateOf("") }
-    var isNameEmpty by remember { mutableStateOf(false) }
-
-    var date by remember { mutableStateOf("") }
-
-    Scaffold(
-        topBar = { NavTopBar(title = "Edit Profile", canNavigateBack = true, navigateUp = { navigation.goBack() },
-            actions = {SaveButton()})
-        },
-    modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
-        Box(
-            modifier =
-            Modifier.fillMaxHeight()
-                .fillMaxWidth()
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp)),
-            contentAlignment = Alignment.TopCenter) {
-            Column(
-                horizontalAlignment = Alignment.Start,
-                verticalArrangement = Arrangement.SpaceEvenly) {
-                Text(
-                    text = "Edit your profile",
-                    fontSize = 36.sp,
-                    fontFamily = Montserrat,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.White,
-                    modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
-                )
-
-                // Text field for the name
-                Text(
-                    text = "Enter your name",
-                    fontSize = 14.sp,
-                    fontFamily = Montserrat,
-                    fontWeight = FontWeight.Normal,
-                    color = md_theme_grey,
-                    modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
-                )
-                Spacer(modifier = Modifier.height(5.dp))
-                OutlinedTextField(
-                    value = name,
-                    onValueChange = {
-                        name = it
-                        isNameEmpty = it.isEmpty() // Update empty state
-                    },
-                    label = {
-                        Text(
-                            text = "Name",
-                            fontSize = 14.sp,
-                            fontFamily = Montserrat,
-                            fontWeight = FontWeight.Normal,
-                            color = Color.White
-                        )
-                    },
-                    modifier =
-                    Modifier.fillMaxWidth(1f)
-                        .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                    textStyle =
-                    TextStyle(
-                        color = Color.White,
-                        fontSize = 16.sp,
-                        fontFamily = Montserrat,
-                        fontWeight = FontWeight.Normal),
-                    colors =
-                    OutlinedTextFieldDefaults.colors(
-                        unfocusedTextColor = Color.White,
-                        unfocusedBorderColor =
-                        if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                        unfocusedLabelColor =
-                        if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                        cursorColor = Color.White,
-                        focusedBorderColor = Color.White,
-                        focusedLabelColor = Color.White,
-                    ))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(top = 30.dp),
-                    horizontalArrangement = Arrangement.Center) {
-                    Spacer(modifier = Modifier.width(20.dp))
-                    // add a button to save the description
-
-                    Spacer(modifier = Modifier.width(20.dp))
-                }
-            }
-        }
-    }
+/**
+ * This function retrieves the user profile from the database.
+ *
+ * @return user profile.
+ */
+private fun retrieveProfile(): UserProfile {
+  // TODO: implement the retrieval of the user profile from the database
+  return UserProfile(
+      "jean.rousseau@epfl.ch",
+      "Jean-Jacques",
+      "Rousseau",
+      Date(),
+      "DarkSkyMan",
+      "profileImageUrl",
+      listOf(),
+      listOf())
 }
 
+/**
+ * This function saves the user profile to the database.
+ *
+ * @param profile : user profile to be saved.
+ */
+private fun updateProfile(
+    profile: UserProfile,
+    name: String,
+    surname: String,
+    mail: String,
+    birthdate: LocalDate,
+    username: String,
+    imageUrl: String?
+) {
+  // TODO: Implement saving the profile to the database
+}
+
+/**
+ * This composable function displays the user profile edit screen.
+ *
+ * @param navigation : Navigation object that manages the navigation in the application.
+ */
 @Composable
-fun SaveButton() {
-    FilledTonalButton(
-        onClick = {
-            // TODO: add logic when save button is clicked
-        },
-        colors =
-        ButtonDefaults.filledTonalButtonColors(
-            containerColor = md_theme_orange, contentColor = Color.White),
-    ) {
+fun UserProfileEditScreen(navigation: Navigation) {
+  val profile = retrieveProfile()
+
+  /** Mutable state variables for the user profile information */
+  var name by remember { mutableStateOf(profile.name) }
+  var isNameEmpty by remember { mutableStateOf(profile.name.isEmpty()) }
+
+  var surname by remember { mutableStateOf(profile.surname) }
+  var isSurnameEmpty by remember { mutableStateOf(profile.surname.isEmpty()) }
+
+  var mail by remember { mutableStateOf(profile.mail) }
+  var isMailEmpty by remember { mutableStateOf(profile.mail.isEmpty()) }
+
+  var birthdate by remember { mutableStateOf(LocalDate.now()) }
+  var isBirthdateEmpty by remember { mutableStateOf(false) }
+
+  var username by remember {
+    mutableStateOf(profile.pseudo)
+  } // TODO: change when pseudo ---> username
+  var isUsernameEmpty by remember { mutableStateOf(profile.pseudo.isEmpty()) }
+
+  var imageUrl by remember { mutableStateOf(profile.profileImageUrl) }
+  var isImageUrlEmpty by remember { mutableStateOf(profile.profileImageUrl?.isEmpty()) }
+
+  Scaffold(
+      topBar = {
+        NavTopBar(
+            title = "Edit Profile",
+            canNavigateBack = true,
+            navigateUp = { navigation.goBack() },
+            actions = {
+              SaveButton(
+                  canSave =
+                      !isNameEmpty && !isSurnameEmpty && !isBirthdateEmpty && !isUsernameEmpty,
+                  action = {
+                    updateProfile(profile, name, surname, mail, birthdate, username, imageUrl)
+                  })
+            })
+      },
+      modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
+        Box(
+            modifier =
+                Modifier.fillMaxHeight()
+                    .fillMaxWidth()
+                    .padding(innerPadding)
+                    .fillMaxSize()
+                    .background(md_theme_light_dark),
+            contentAlignment = Alignment.TopCenter) {
+              Column(
+                  horizontalAlignment = Alignment.Start,
+                  verticalArrangement = Arrangement.SpaceEvenly) {
+                    Text(
+                        text = "Change your information below",
+                        fontSize = 14.sp,
+                        fontFamily = Montserrat,
+                        fontWeight = FontWeight.Normal,
+                        color = md_theme_grey,
+                        modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
+                    )
+
+                    Spacer(modifier = Modifier.height(10.dp))
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = {
+                          name = it
+                          isNameEmpty = it.isEmpty() // Update empty state
+                        },
+                        label = {
+                          Text(
+                              text = "Name",
+                              fontSize = 14.sp,
+                              fontFamily = Montserrat,
+                              fontWeight = FontWeight.Normal,
+                              color = Color.White)
+                        },
+                        modifier =
+                            Modifier.fillMaxWidth(1f)
+                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
+                        textStyle =
+                            TextStyle(
+                                color = Color.White,
+                                fontSize = 16.sp,
+                                fontFamily = Montserrat,
+                                fontWeight = FontWeight.Normal),
+                        colors =
+                            OutlinedTextFieldDefaults.colors(
+                                unfocusedTextColor = Color.White,
+                                unfocusedBorderColor =
+                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                                unfocusedLabelColor =
+                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                                cursorColor = Color.White,
+                                focusedBorderColor =
+                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                                focusedLabelColor = Color.White,
+                            ))
+
+                    Spacer(modifier = Modifier.height(7.dp))
+                    OutlinedTextField(
+                        value = surname,
+                        onValueChange = {
+                          surname = it
+                          isSurnameEmpty = it.isEmpty() // Update empty state
+                        },
+                        label = {
+                          Text(
+                              text = "Surname",
+                              fontSize = 14.sp,
+                              fontFamily = Montserrat,
+                              fontWeight = FontWeight.Normal,
+                              color = Color.White)
+                        },
+                        modifier =
+                            Modifier.fillMaxWidth(1f)
+                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
+                        textStyle =
+                            TextStyle(
+                                color = Color.White,
+                                fontSize = 16.sp,
+                                fontFamily = Montserrat,
+                                fontWeight = FontWeight.Normal),
+                        colors =
+                            OutlinedTextFieldDefaults.colors(
+                                unfocusedTextColor = Color.White,
+                                unfocusedBorderColor =
+                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
+                                unfocusedLabelColor =
+                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
+                                cursorColor = Color.White,
+                                focusedBorderColor =
+                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
+                                focusedLabelColor = Color.White,
+                            ))
+
+                    Spacer(modifier = Modifier.height(7.dp))
+                    OutlinedTextField(
+                        value = mail,
+                        onValueChange = {
+                          mail = it
+                          isMailEmpty = it.isEmpty() // Update empty state
+                        },
+                        label = {
+                          Text(
+                              text = "Mail",
+                              fontSize = 14.sp,
+                              fontFamily = Montserrat,
+                              fontWeight = FontWeight.Normal,
+                              color = Color.White)
+                        },
+                        modifier =
+                            Modifier.fillMaxWidth(1f)
+                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
+                        textStyle =
+                            TextStyle(
+                                color = Color.White,
+                                fontSize = 16.sp,
+                                fontFamily = Montserrat,
+                                fontWeight = FontWeight.Normal),
+                        colors =
+                            OutlinedTextFieldDefaults.colors(
+                                unfocusedTextColor = Color.White,
+                                unfocusedBorderColor =
+                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
+                                unfocusedLabelColor =
+                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
+                                cursorColor = Color.White,
+                                focusedBorderColor =
+                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
+                                focusedLabelColor = Color.White,
+                            ))
+
+                    Spacer(modifier = Modifier.height(7.dp))
+                    OutlinedTextField(
+                        value = username,
+                        onValueChange = {
+                          username = it
+                          isUsernameEmpty = it.isEmpty() // Update empty state
+                        },
+                        label = {
+                          Text(
+                              text = "Username",
+                              fontSize = 14.sp,
+                              fontFamily = Montserrat,
+                              fontWeight = FontWeight.Normal,
+                              color = Color.White)
+                        },
+                        modifier =
+                            Modifier.fillMaxWidth(1f)
+                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
+                        textStyle =
+                            TextStyle(
+                                color = Color.White,
+                                fontSize = 16.sp,
+                                fontFamily = Montserrat,
+                                fontWeight = FontWeight.Normal),
+                        colors =
+                            OutlinedTextFieldDefaults.colors(
+                                unfocusedTextColor = Color.White,
+                                unfocusedBorderColor =
+                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
+                                unfocusedLabelColor =
+                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
+                                cursorColor = Color.White,
+                                focusedBorderColor =
+                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
+                                focusedLabelColor = Color.White,
+                            ))
+
+                    Spacer(modifier = Modifier.height(7.dp))
+                    val isOpen = remember { mutableStateOf(false) }
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                      OutlinedTextField(
+                          readOnly = true,
+                          value = birthdate.format(DateTimeFormatter.ISO_DATE),
+                          label = {
+                            Text(
+                                text = "Date of birth",
+                                fontSize = 14.sp,
+                                fontFamily = Montserrat,
+                                fontWeight = FontWeight.Normal,
+                                color = Color.White)
+                          },
+                          onValueChange = {},
+                          modifier =
+                              Modifier.padding(top = 5.dp, bottom = 5.dp, start = 30.dp).weight(1f),
+                          textStyle =
+                              TextStyle(
+                                  color = Color.White,
+                                  fontSize = 16.sp,
+                                  fontFamily = Montserrat,
+                                  fontWeight = FontWeight.Normal),
+                          colors =
+                              OutlinedTextFieldDefaults.colors(
+                                  unfocusedTextColor = Color.White,
+                                  unfocusedBorderColor =
+                                      if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
+                                  unfocusedLabelColor =
+                                      if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
+                                  cursorColor = Color.White,
+                                  focusedBorderColor =
+                                      if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
+                                  focusedLabelColor = Color.White,
+                              ))
+
+                      IconButton(
+                          modifier = Modifier.padding(end = 30.dp),
+                          onClick = { isOpen.value = true } // show de dialog
+                          ) {
+                            Icon(
+                                imageVector = Icons.Default.CalendarMonth,
+                                contentDescription = "Calendar",
+                                tint = Color.White)
+                          }
+                    }
+
+                    if (isOpen.value) {
+                      CustomDatePickerDialog(
+                          onAccept = {
+                            isOpen.value = false // close dialog
+
+                            if (it != null) { // Set the date
+                              birthdate =
+                                  Instant.ofEpochMilli(it).atZone(ZoneId.of("UTC")).toLocalDate()
+                            }
+                          },
+                          onCancel = {
+                            isOpen.value = false // close dialog
+                          })
+                    }
+                  }
+            }
+      }
+}
+
+/**
+ * This composable function displays a save button.
+ *
+ * @param canSave : boolean indicating if the button is enabled.
+ * @param action : function to be called when the button is clicked.
+ */
+@Composable
+fun SaveButton(canSave: Boolean = true, action: () -> Unit = {}) {
+  val showDialog = remember { mutableStateOf(false) }
+
+  if (showDialog.value) {
+    AlertDialog(
+        backgroundColor = Color.White,
+        onDismissRequest = {},
+        title = { Text(text = "Profile saved! \uD83D\uDE0A", color = Color.Black) },
+        confirmButton = {
+          FilledTonalButton(
+              onClick = { showDialog.value = false },
+              colors = ButtonDefaults.filledTonalButtonColors(containerColor = md_theme_orange),
+              modifier = Modifier.width(108.dp).height(30.dp),
+          ) {
+            Text(
+                text = "Go back",
+                fontSize = 14.sp,
+                fontFamily = Montserrat,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.White)
+          }
+        })
+  }
+
+  FilledTonalButton(
+      onClick = {
+        if (canSave) {
+          showDialog.value = true
+          action()
+        }
+      },
+      colors =
+          ButtonDefaults.filledTonalButtonColors(
+              containerColor = md_theme_orange, contentColor = Color.White)) {
         Text(
             text = "Save",
             fontSize = 18.sp,
             fontFamily = Montserrat,
             fontWeight = FontWeight.SemiBold,
             color = Color.White)
-    }
+      }
 }
 
+/**
+ * This composable function displays a custom date picker dialog.
+ *
+ * @param onAccept : function to be called when the user accepts the date.
+ * @param onCancel : function to be called when the user cancels the date selection.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CustomDatePickerDialog(onAccept: (Long?) -> Unit, onCancel: () -> Unit) {
+  val state = rememberDatePickerState()
+
+  DatePickerDialog(
+      onDismissRequest = {},
+      confirmButton = {
+        Button(onClick = { onAccept(state.selectedDateMillis) }) { Text("Accept") }
+      },
+      dismissButton = { Button(onClick = onCancel) { Text("Cancel") } },
+      colors = DatePickerDefaults.colors()) { // TODO: Change the colors here
+        DatePicker(state = state)
+      }
+}
+
+/** This function previews the UserProfileEditScreen. */
 @Preview
 @Composable
-        /* Visual preview of the User Profile Edit Screen */
 fun UserProfileEditScreenPreview() {
-    val navController = rememberNavController()
-    val navigation = remember(navController) { Navigation(navController) }
-    UserProfileEditScreen(navigation)
+  val navController = rememberNavController()
+  val navigation = remember(navController) { Navigation(navController) }
+  UserProfileEditScreen(navigation)
 }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -1,0 +1,174 @@
+package com.example.triptracker.view.profile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.rememberNavController
+import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.view.NavTopBar
+import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.NavigationBar
+import com.example.triptracker.view.theme.Montserrat
+import com.example.triptracker.view.theme.md_theme_grey
+import com.example.triptracker.view.theme.md_theme_light_dark
+import com.example.triptracker.view.theme.md_theme_light_error
+import com.example.triptracker.view.theme.md_theme_orange
+import java.util.Date
+
+@Composable
+fun UserProfileEditScreen(navigation: Navigation) {
+    val profile = // TODO: replace with actual user profile
+        UserProfile(
+            "mail", "name", "surname", Date(), "pseudo", "profileImageUrl", listOf(), listOf())
+
+    var mail by remember { mutableStateOf("") }
+    var isMailEmpty by remember { mutableStateOf(false) }
+
+    var name by remember { mutableStateOf("") }
+    var isNameEmpty by remember { mutableStateOf(false) }
+
+    var date by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = { NavTopBar(title = "Edit Profile", canNavigateBack = true, navigateUp = { navigation.goBack() },
+            actions = {SaveButton()})
+        },
+    modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
+        Box(
+            modifier =
+            Modifier.fillMaxHeight()
+                .fillMaxWidth()
+                .padding(innerPadding)
+                .fillMaxSize()
+                .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp)),
+            contentAlignment = Alignment.TopCenter) {
+            Column(
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.SpaceEvenly) {
+                Text(
+                    text = "Edit your profile",
+                    fontSize = 36.sp,
+                    fontFamily = Montserrat,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
+                )
+
+                // Text field for the name
+                Text(
+                    text = "Enter your name",
+                    fontSize = 14.sp,
+                    fontFamily = Montserrat,
+                    fontWeight = FontWeight.Normal,
+                    color = md_theme_grey,
+                    modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = {
+                        name = it
+                        isNameEmpty = it.isEmpty() // Update empty state
+                    },
+                    label = {
+                        Text(
+                            text = "Name",
+                            fontSize = 14.sp,
+                            fontFamily = Montserrat,
+                            fontWeight = FontWeight.Normal,
+                            color = Color.White
+                        )
+                    },
+                    modifier =
+                    Modifier.fillMaxWidth(1f)
+                        .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
+                    textStyle =
+                    TextStyle(
+                        color = Color.White,
+                        fontSize = 16.sp,
+                        fontFamily = Montserrat,
+                        fontWeight = FontWeight.Normal),
+                    colors =
+                    OutlinedTextFieldDefaults.colors(
+                        unfocusedTextColor = Color.White,
+                        unfocusedBorderColor =
+                        if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                        unfocusedLabelColor =
+                        if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                        cursorColor = Color.White,
+                        focusedBorderColor = Color.White,
+                        focusedLabelColor = Color.White,
+                    ))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 30.dp),
+                    horizontalArrangement = Arrangement.Center) {
+                    Spacer(modifier = Modifier.width(20.dp))
+                    // add a button to save the description
+
+                    Spacer(modifier = Modifier.width(20.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SaveButton() {
+    FilledTonalButton(
+        onClick = {
+            // TODO: add logic when save button is clicked
+        },
+        colors =
+        ButtonDefaults.filledTonalButtonColors(
+            containerColor = md_theme_orange, contentColor = Color.White),
+    ) {
+        Text(
+            text = "Save",
+            fontSize = 18.sp,
+            fontFamily = Montserrat,
+            fontWeight = FontWeight.SemiBold,
+            color = Color.White)
+    }
+}
+
+@Preview
+@Composable
+        /* Visual preview of the User Profile Edit Screen */
+fun UserProfileEditScreenPreview() {
+    val navController = rememberNavController()
+    val navigation = remember(navController) { Navigation(navController) }
+    UserProfileEditScreen(navigation)
+}

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.example.triptracker.model.profile.UserProfile
-import com.example.triptracker.view.NavTopBar
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.NavigationBar
 import com.example.triptracker.view.theme.Montserrat
@@ -126,18 +125,19 @@ fun UserProfileEditScreen(navigation: Navigation) {
 
   Scaffold(
       topBar = {
-        NavTopBar(
-            title = "Edit Profile",
-            canNavigateBack = true,
-            navigateUp = { navigation.goBack() },
-            actions = {})
+        // NavTopBar(
+        //    title = "Edit Profile",
+        //    canNavigateBack = true,
+        //    navigateUp = { navigation.goBack() },
+        //    actions = {})
       },
       bottomBar = { NavigationBar(navigation) },
       modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
         Box(
             modifier =
-                Modifier.fillMaxHeight().padding(innerPadding)
-                    .padding(top = 35.dp, bottom = 35.dp, start = 25.dp, end = 25.dp)
+                Modifier.fillMaxHeight()
+                    .padding(innerPadding)
+                    .padding(top = 30.dp, bottom = 30.dp, start = 25.dp, end = 25.dp)
                     .fillMaxWidth()
                     .background(md_theme_light_dark, shape = RoundedCornerShape(20.dp)),
             contentAlignment = Alignment.TopCenter) {
@@ -205,12 +205,12 @@ fun UserProfileEditScreen(navigation: Navigation) {
                                   fontWeight = FontWeight.Normal),
                           colors =
                               OutlinedTextFieldDefaults.colors(
-                                  unfocusedTextColor = Color.White,
+                                  unfocusedTextColor = md_theme_grey,
                                   unfocusedBorderColor =
                                       if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
                                   unfocusedLabelColor =
                                       if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
-                                  cursorColor = Color.White,
+                                  cursorColor = md_theme_grey,
                                   focusedBorderColor =
                                       if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
                                   focusedLabelColor = Color.White,
@@ -241,19 +241,21 @@ fun UserProfileEditScreen(navigation: Navigation) {
                             isOpen.value = false // close dialog
                           })
                     }
-                    Spacer(modifier = Modifier.height(50.dp))
-                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                      SaveButton(
-                          canSave =
-                              !isNameEmpty &&
-                                  !isSurnameEmpty &&
-                                  !isBirthdateEmpty &&
-                                  !isUsernameEmpty,
-                          action = {
-                            updateProfile(
-                                profile, name, surname, mail, birthdate, username, imageUrl)
-                          })
-                    }
+                    Spacer(modifier = Modifier.height(25.dp))
+                    Box(
+                        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                        contentAlignment = Alignment.Center) {
+                          SaveButton(
+                              canSave =
+                                  !isNameEmpty &&
+                                      !isSurnameEmpty &&
+                                      !isBirthdateEmpty &&
+                                      !isUsernameEmpty,
+                              action = {
+                                updateProfile(
+                                    profile, name, surname, mail, birthdate, username, imageUrl)
+                              })
+                        }
                   }
             }
       }
@@ -298,10 +300,10 @@ fun ProfileEditTextField(
               fontWeight = FontWeight.Normal),
       colors =
           OutlinedTextFieldDefaults.colors(
-              unfocusedTextColor = Color.White,
+              unfocusedTextColor = md_theme_grey,
               unfocusedBorderColor = if (isEmpty) md_theme_light_error else md_theme_grey,
               unfocusedLabelColor = if (isEmpty) md_theme_light_error else md_theme_grey,
-              cursorColor = Color.White,
+              cursorColor = md_theme_grey,
               focusedBorderColor = if (isEmpty) md_theme_light_error else md_theme_grey,
               focusedLabelColor = Color.White,
           ))

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -11,24 +11,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.AlertDialog
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.Text
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDefaults
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -47,410 +39,136 @@ import androidx.navigation.compose.rememberNavController
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.NavTopBar
 import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.NavigationBar
 import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
 import com.example.triptracker.view.theme.md_theme_light_error
 import com.example.triptracker.view.theme.md_theme_orange
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import java.util.Date
 
-/**
- * This function retrieves the user profile from the database.
- *
- * @return user profile.
- */
-private fun retrieveProfile(): UserProfile {
-  // TODO: implement the retrieval of the user profile from the database
-  return UserProfile(
-      "jean.rousseau@epfl.ch",
-      "Jean-Jacques",
-      "Rousseau",
-      Date(),
-      "DarkSkyMan",
-      "profileImageUrl",
-      listOf(),
-      listOf())
-}
-
-/**
- * This function saves the user profile to the database.
- *
- * @param profile : user profile to be saved.
- */
-private fun updateProfile(
-    profile: UserProfile,
-    name: String,
-    surname: String,
-    mail: String,
-    birthdate: LocalDate,
-    username: String,
-    imageUrl: String?
-) {
-  // TODO: Implement saving the profile to the database
-}
-
-/**
- * This composable function displays the user profile edit screen.
- *
- * @param navigation : Navigation object that manages the navigation in the application.
- */
 @Composable
 fun UserProfileEditScreen(navigation: Navigation) {
-  val profile = retrieveProfile()
+    val profile = // TODO: replace with actual user profile
+        UserProfile(
+            "mail", "name", "surname", Date(), "pseudo", "profileImageUrl", listOf(), listOf())
 
-  /** Mutable state variables for the user profile information */
-  var name by remember { mutableStateOf(profile.name) }
-  var isNameEmpty by remember { mutableStateOf(profile.name.isEmpty()) }
+    var mail by remember { mutableStateOf("") }
+    var isMailEmpty by remember { mutableStateOf(false) }
 
-  var surname by remember { mutableStateOf(profile.surname) }
-  var isSurnameEmpty by remember { mutableStateOf(profile.surname.isEmpty()) }
+    var name by remember { mutableStateOf("") }
+    var isNameEmpty by remember { mutableStateOf(false) }
 
-  var mail by remember { mutableStateOf(profile.mail) }
-  var isMailEmpty by remember { mutableStateOf(profile.mail.isEmpty()) }
+    var date by remember { mutableStateOf("") }
 
-  var birthdate by remember { mutableStateOf(LocalDate.now()) }
-  var isBirthdateEmpty by remember { mutableStateOf(false) }
-
-  var username by remember {
-    mutableStateOf(profile.pseudo)
-  } // TODO: change when pseudo ---> username
-  var isUsernameEmpty by remember { mutableStateOf(profile.pseudo.isEmpty()) }
-
-  var imageUrl by remember { mutableStateOf(profile.profileImageUrl) }
-  var isImageUrlEmpty by remember { mutableStateOf(profile.profileImageUrl?.isEmpty()) }
-
-  Scaffold(
-      topBar = {
-        NavTopBar(
-            title = "Edit Profile",
-            canNavigateBack = true,
-            navigateUp = { navigation.goBack() },
-            actions = {
-              SaveButton(
-                  canSave =
-                      !isNameEmpty && !isSurnameEmpty && !isBirthdateEmpty && !isUsernameEmpty,
-                  action = {
-                    updateProfile(profile, name, surname, mail, birthdate, username, imageUrl)
-                  })
-            })
-      },
-      modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
+    Scaffold(
+        topBar = { NavTopBar(title = "Edit Profile", canNavigateBack = true, navigateUp = { navigation.goBack() },
+            actions = {SaveButton()})
+        },
+    modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
         Box(
             modifier =
-                Modifier.fillMaxHeight()
-                    .fillMaxWidth()
-                    .padding(innerPadding)
-                    .fillMaxSize()
-                    .background(md_theme_light_dark),
+            Modifier.fillMaxHeight()
+                .fillMaxWidth()
+                .padding(innerPadding)
+                .fillMaxSize()
+                .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp)),
             contentAlignment = Alignment.TopCenter) {
-              Column(
-                  horizontalAlignment = Alignment.Start,
-                  verticalArrangement = Arrangement.SpaceEvenly) {
-                    Text(
-                        text = "Change your information below",
-                        fontSize = 14.sp,
+            Column(
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.SpaceEvenly) {
+                Text(
+                    text = "Edit your profile",
+                    fontSize = 36.sp,
+                    fontFamily = Montserrat,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                    modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
+                )
+
+                // Text field for the name
+                Text(
+                    text = "Enter your name",
+                    fontSize = 14.sp,
+                    fontFamily = Montserrat,
+                    fontWeight = FontWeight.Normal,
+                    color = md_theme_grey,
+                    modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
+                )
+                Spacer(modifier = Modifier.height(5.dp))
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = {
+                        name = it
+                        isNameEmpty = it.isEmpty() // Update empty state
+                    },
+                    label = {
+                        Text(
+                            text = "Name",
+                            fontSize = 14.sp,
+                            fontFamily = Montserrat,
+                            fontWeight = FontWeight.Normal,
+                            color = Color.White
+                        )
+                    },
+                    modifier =
+                    Modifier.fillMaxWidth(1f)
+                        .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
+                    textStyle =
+                    TextStyle(
+                        color = Color.White,
+                        fontSize = 16.sp,
                         fontFamily = Montserrat,
-                        fontWeight = FontWeight.Normal,
-                        color = md_theme_grey,
-                        modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
-                    )
+                        fontWeight = FontWeight.Normal),
+                    colors =
+                    OutlinedTextFieldDefaults.colors(
+                        unfocusedTextColor = Color.White,
+                        unfocusedBorderColor =
+                        if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                        unfocusedLabelColor =
+                        if (isNameEmpty) md_theme_light_error else md_theme_grey,
+                        cursorColor = Color.White,
+                        focusedBorderColor = Color.White,
+                        focusedLabelColor = Color.White,
+                    ))
 
-                    Spacer(modifier = Modifier.height(10.dp))
-                    OutlinedTextField(
-                        value = name,
-                        onValueChange = {
-                          name = it
-                          isNameEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Name",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isNameEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 30.dp),
+                    horizontalArrangement = Arrangement.Center) {
+                    Spacer(modifier = Modifier.width(20.dp))
+                    // add a button to save the description
 
-                    Spacer(modifier = Modifier.height(7.dp))
-                    OutlinedTextField(
-                        value = surname,
-                        onValueChange = {
-                          surname = it
-                          isSurnameEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Surname",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isSurnameEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    OutlinedTextField(
-                        value = mail,
-                        onValueChange = {
-                          mail = it
-                          isMailEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Mail",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isMailEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    OutlinedTextField(
-                        value = username,
-                        onValueChange = {
-                          username = it
-                          isUsernameEmpty = it.isEmpty() // Update empty state
-                        },
-                        label = {
-                          Text(
-                              text = "Username",
-                              fontSize = 14.sp,
-                              fontFamily = Montserrat,
-                              fontWeight = FontWeight.Normal,
-                              color = Color.White)
-                        },
-                        modifier =
-                            Modifier.fillMaxWidth(1f)
-                                .padding(top = 5.dp, bottom = 5.dp, start = 30.dp, end = 30.dp),
-                        textStyle =
-                            TextStyle(
-                                color = Color.White,
-                                fontSize = 16.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal),
-                        colors =
-                            OutlinedTextFieldDefaults.colors(
-                                unfocusedTextColor = Color.White,
-                                unfocusedBorderColor =
-                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
-                                unfocusedLabelColor =
-                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
-                                cursorColor = Color.White,
-                                focusedBorderColor =
-                                    if (isUsernameEmpty) md_theme_light_error else md_theme_grey,
-                                focusedLabelColor = Color.White,
-                            ))
-
-                    Spacer(modifier = Modifier.height(7.dp))
-                    val isOpen = remember { mutableStateOf(false) }
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                      OutlinedTextField(
-                          readOnly = true,
-                          value = birthdate.format(DateTimeFormatter.ISO_DATE),
-                          label = {
-                            Text(
-                                text = "Date of birth",
-                                fontSize = 14.sp,
-                                fontFamily = Montserrat,
-                                fontWeight = FontWeight.Normal,
-                                color = Color.White)
-                          },
-                          onValueChange = {},
-                          modifier =
-                              Modifier.padding(top = 5.dp, bottom = 5.dp, start = 30.dp).weight(1f),
-                          textStyle =
-                              TextStyle(
-                                  color = Color.White,
-                                  fontSize = 16.sp,
-                                  fontFamily = Montserrat,
-                                  fontWeight = FontWeight.Normal),
-                          colors =
-                              OutlinedTextFieldDefaults.colors(
-                                  unfocusedTextColor = Color.White,
-                                  unfocusedBorderColor =
-                                      if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
-                                  unfocusedLabelColor =
-                                      if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
-                                  cursorColor = Color.White,
-                                  focusedBorderColor =
-                                      if (isBirthdateEmpty) md_theme_light_error else md_theme_grey,
-                                  focusedLabelColor = Color.White,
-                              ))
-
-                      IconButton(
-                          modifier = Modifier.padding(end = 30.dp),
-                          onClick = { isOpen.value = true } // show de dialog
-                          ) {
-                            Icon(
-                                imageVector = Icons.Default.CalendarMonth,
-                                contentDescription = "Calendar",
-                                tint = Color.White)
-                          }
-                    }
-
-                    if (isOpen.value) {
-                      CustomDatePickerDialog(
-                          onAccept = {
-                            isOpen.value = false // close dialog
-
-                            if (it != null) { // Set the date
-                              birthdate =
-                                  Instant.ofEpochMilli(it).atZone(ZoneId.of("UTC")).toLocalDate()
-                            }
-                          },
-                          onCancel = {
-                            isOpen.value = false // close dialog
-                          })
-                    }
-                  }
+                    Spacer(modifier = Modifier.width(20.dp))
+                }
             }
-      }
+        }
+    }
 }
 
-/**
- * This composable function displays a save button.
- *
- * @param canSave : boolean indicating if the button is enabled.
- * @param action : function to be called when the button is clicked.
- */
 @Composable
-fun SaveButton(canSave: Boolean = true, action: () -> Unit = {}) {
-  val showDialog = remember { mutableStateOf(false) }
-
-  if (showDialog.value) {
-    AlertDialog(
-        backgroundColor = Color.White,
-        onDismissRequest = {},
-        title = { Text(text = "Profile saved! \uD83D\uDE0A", color = Color.Black) },
-        confirmButton = {
-          FilledTonalButton(
-              onClick = { showDialog.value = false },
-              colors = ButtonDefaults.filledTonalButtonColors(containerColor = md_theme_orange),
-              modifier = Modifier.width(108.dp).height(30.dp),
-          ) {
-            Text(
-                text = "Go back",
-                fontSize = 14.sp,
-                fontFamily = Montserrat,
-                fontWeight = FontWeight.SemiBold,
-                color = Color.White)
-          }
-        })
-  }
-
-  FilledTonalButton(
-      onClick = {
-        if (canSave) {
-          showDialog.value = true
-          action()
-        }
-      },
-      colors =
-          ButtonDefaults.filledTonalButtonColors(
-              containerColor = md_theme_orange, contentColor = Color.White)) {
+fun SaveButton() {
+    FilledTonalButton(
+        onClick = {
+            // TODO: add logic when save button is clicked
+        },
+        colors =
+        ButtonDefaults.filledTonalButtonColors(
+            containerColor = md_theme_orange, contentColor = Color.White),
+    ) {
         Text(
             text = "Save",
             fontSize = 18.sp,
             fontFamily = Montserrat,
             fontWeight = FontWeight.SemiBold,
             color = Color.White)
-      }
+    }
 }
 
-/**
- * This composable function displays a custom date picker dialog.
- *
- * @param onAccept : function to be called when the user accepts the date.
- * @param onCancel : function to be called when the user cancels the date selection.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun CustomDatePickerDialog(onAccept: (Long?) -> Unit, onCancel: () -> Unit) {
-  val state = rememberDatePickerState()
-
-  DatePickerDialog(
-      onDismissRequest = {},
-      confirmButton = {
-        Button(onClick = { onAccept(state.selectedDateMillis) }) { Text("Accept") }
-      },
-      dismissButton = { Button(onClick = onCancel) { Text("Cancel") } },
-      colors = DatePickerDefaults.colors()) { // TODO: Change the colors here
-        DatePicker(state = state)
-      }
-}
-
-/** This function previews the UserProfileEditScreen. */
 @Preview
 @Composable
+        /* Visual preview of the User Profile Edit Screen */
 fun UserProfileEditScreenPreview() {
-  val navController = rememberNavController()
-  val navigation = remember(navController) { Navigation(navController) }
-  UserProfileEditScreen(navigation)
+    val navController = rememberNavController()
+    val navigation = remember(navController) { Navigation(navController) }
+    UserProfileEditScreen(navigation)
 }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -54,10 +54,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.Navigation
@@ -134,9 +132,7 @@ fun UserProfileEditScreen(navigation: Navigation) {
   var isBirthdateEmpty by remember { mutableStateOf(false) }
 
   /* Mutable state variable that holds the username of the user profile */
-  var username by remember {
-    mutableStateOf(profile.username)
-  }
+  var username by remember { mutableStateOf(profile.username) }
   var isUsernameEmpty by remember { mutableStateOf(profile.username.isEmpty()) }
 
   /* Mutable state variable that holds the image url of the user profile */
@@ -517,10 +513,10 @@ fun InsertPicture(
 }
 
 /** This function previews the UserProfileEditScreen. */
-//@Preview
-//@Composable
-//fun UserProfileEditScreenPreview() {
+// @Preview
+// @Composable
+// fun UserProfileEditScreenPreview() {
 //  val navController = rememberNavController()
 //  val navigation = remember(navController) { Navigation(navController) }
 //  UserProfileEditScreen(navigation)
-//}
+// }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -69,7 +69,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.Date
 
 /**
  * This function retrieves the user profile from the database.
@@ -82,7 +81,7 @@ private fun retrieveProfile(): UserProfile {
       "jean.rousseau@epfl.ch",
       "Jean-Jacques",
       "Rousseau",
-      Date(),
+      LocalDate.now().format(DateTimeFormatter.ISO_DATE),
       "DarkSkyMan",
       "profileImageUrl",
       listOf(),
@@ -99,7 +98,7 @@ private fun updateProfile(
     name: String,
     surname: String,
     mail: String,
-    birthdate: LocalDate,
+    birthdate: String,
     username: String,
     imageUrl: String?
 ) {
@@ -128,7 +127,7 @@ fun UserProfileEditScreen(navigation: Navigation) {
   var isMailEmpty by remember { mutableStateOf(profile.mail.isEmpty()) }
 
   /* Mutable state variable that holds the birthdate of the user profile */
-  var birthdate by remember { mutableStateOf(LocalDate.now()) }
+  var birthdate by remember { mutableStateOf(profile.birthdate) }
   var isBirthdateEmpty by remember { mutableStateOf(false) }
 
   /* Mutable state variable that holds the username of the user profile */
@@ -281,7 +280,7 @@ fun UserProfileEditScreen(navigation: Navigation) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                       OutlinedTextField(
                           readOnly = true,
-                          value = birthdate.format(DateTimeFormatter.ISO_DATE),
+                          value = birthdate,
                           label = {},
                           onValueChange = {},
                           modifier = Modifier.padding(bottom = 5.dp, start = 30.dp).weight(1f),
@@ -321,7 +320,10 @@ fun UserProfileEditScreen(navigation: Navigation) {
 
                             if (it != null) { // Set the date
                               birthdate =
-                                  Instant.ofEpochMilli(it).atZone(ZoneId.of("UTC")).toLocalDate()
+                                  Instant.ofEpochMilli(it)
+                                      .atZone(ZoneId.of("UTC"))
+                                      .toLocalDate()
+                                      .format(DateTimeFormatter.ISO_DATE)
                             }
                           },
                           onCancel = {
@@ -516,7 +518,7 @@ fun InsertPicture(
 // @Preview
 // @Composable
 // fun UserProfileEditScreenPreview() {
-//  val navController = rememberNavController()
-//  val navigation = remember(navController) { Navigation(navController) }
-//  UserProfileEditScreen(navigation)
+// val navController = rememberNavController()
+// val navigation = remember(navController) { Navigation(navController) }
+// UserProfileEditScreen(navigation)
 // }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -145,7 +145,6 @@ fun UserProfileEditScreen(navigation: Navigation) {
 
   // Variable to store the state of the new profile picture
   var selectedPicture by remember { mutableStateOf<Uri?>(null) }
-
   // Launcher for the pick multiple media activity
   val pickMedia =
       rememberLauncherForActivityResult(ActivityResultContracts.PickVisualMedia()) { picture ->
@@ -160,13 +159,7 @@ fun UserProfileEditScreen(navigation: Navigation) {
       }
 
   Scaffold(
-      topBar = {
-        // NavTopBar(
-        //    title = "Edit Profile",
-        //    canNavigateBack = true,
-        //    navigateUp = { navigation.goBack() },
-        //    actions = {})
-      },
+      topBar = {},
       bottomBar = { NavigationBar(navigation) },
       modifier = Modifier.testTag("UserProfileEditScreen")) { innerPadding ->
         Box(
@@ -366,16 +359,13 @@ fun UserProfileEditScreen(navigation: Navigation) {
  * @param value : value of the text field.
  * @param onValueChange : function to be called when the value of the text field changes.
  * @param isEmpty : boolean indicating if the text field is empty.
- * @param modifier : modifier for the text field.
  */
 @Composable
 fun ProfileEditTextField(
     label: String,
     value: String,
     onValueChange: (String) -> Unit,
-    isEmpty: Boolean,
-    modifier: Modifier =
-        Modifier.fillMaxWidth(1f).padding(bottom = 5.dp, start = 30.dp, end = 30.dp)
+    isEmpty: Boolean
 ) {
   Text(
       text = label,
@@ -389,7 +379,7 @@ fun ProfileEditTextField(
       value = value,
       onValueChange = { onValueChange(it) },
       label = {},
-      modifier = modifier,
+      modifier = Modifier.fillMaxWidth(1f).padding(bottom = 5.dp, start = 30.dp, end = 30.dp),
       textStyle =
           TextStyle(
               color = Color.White,

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowers.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowers.kt
@@ -75,8 +75,6 @@ fun UserProfileFollowers(
                             textAlign = TextAlign.Center,
                             letterSpacing = 0.5.sp,
                         ),
-                    // modifier = Modifier.weight(1f)
-                    // .padding(horizontal = 16.dp)
                     modifier =
                         Modifier.width(250.dp)
                             .height(37.dp)
@@ -94,3 +92,30 @@ fun UserProfileFollowers(
         }
       }
 }
+
+//// TODO: remove this preview
+// @Preview(showBackground = true)
+// @Composable
+// fun UserProfileFollowersPreview() {
+//    val viewModel = UserProfileViewModel()
+//
+//    //val list = viewModel.userProfileList.value
+//    //val profile = viewModel.getUserProfile("cleorenaud38@gmail.com")
+//
+//    val navController = rememberNavController()
+//    val navigation = remember(navController) { Navigation(navController) }
+//
+//    val mockUser1 = UserProfile(
+//        mail = "cleorenaud38@gmail.com",
+//        name = "Cleo",
+//        surname = "Renaud",
+//        birthdate = "08-February-2004",
+//        username = "Cleoooo",
+//        profileImageUrl =
+// "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+//        followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+//        following = emptyList()
+//    )
+//
+//    UserProfileFollowers(navigation, viewModel, mockUser1)
+// }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowing.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowing.kt
@@ -75,7 +75,11 @@ fun UserProfileFollowing(
                             textAlign = TextAlign.Center,
                             letterSpacing = 0.5.sp,
                         ),
-                    modifier = Modifier.weight(1f).testTag("FollowingTitle"))
+                    modifier =
+                        Modifier.width(250.dp)
+                            .height(37.dp)
+                            .padding(5.dp)
+                            .testTag("FollowingTitle"))
                 Box(modifier = Modifier.size(60.dp))
               }
             }
@@ -88,3 +92,31 @@ fun UserProfileFollowing(
         }
       }
 }
+
+//// TODO: remove this preview
+// @Preview(showBackground = true)
+// @Composable
+// fun UserProfileFollowingPreview() {
+//  val viewModel = UserProfileViewModel()
+//
+//  // val list = viewModel.userProfileList.value
+//  // val profile = viewModel.getUserProfile("cleorenaud38@gmail.com")
+//
+//  val navController = rememberNavController()
+//  val navigation = remember(navController) { Navigation(navController) }
+//
+//  val mockUser1 =
+//      UserProfile(
+//          mail = "cleorenaud38@gmail.com",
+//          name = "Cleo",
+//          surname = "Renaud",
+//          birthdate = "08-February-2004",
+//          username = "Cleoooo",
+//          profileImageUrl =
+//
+// "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+//          followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+//          following = emptyList())
+//
+//  UserProfileFollowing(navigation, viewModel, mockUser1)
+// }

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.triptracker.viewmodel
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/com/example/triptracker/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/UserProfileViewModel.kt
@@ -53,63 +53,29 @@ class UserProfileViewModel(
   }
 
   /**
-   * This function adds new followers to the user profile in the database.
+   * Function that add the follower to the user profile
    *
-   * @param userProfile : user profile to update
-   * @param follower : follower to add
+   * @param userProfile : the user profile to which we add a follower
+   * @param follower : the user profile of the follower to add
    */
-  fun addFollowersInDb(userProfile: UserProfile, follower: UserProfile) {
-    val updatedProfile = userProfile.copy(followers = userProfile.followers + follower.mail)
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowerProfile = follower.copy(following = follower.following + userProfile.mail)
-    userProfileRepository.updateUserProfile(updatedFollowerProfile)
+  fun addFollower(userProfile: UserProfile, follower: UserProfile) {
+    val updatedUserProfile = userProfile.copy(followers = userProfile.followers + follower.mail)
+    val updatedFollower = follower.copy(following = follower.following + userProfile.mail)
+    userProfileRepository.updateUserProfile(updatedUserProfile)
+    userProfileRepository.updateUserProfile(updatedFollower)
   }
 
   /**
-   * This function adds new following to the user profile in the database.
+   * Function that remove the follower from the user profile
    *
-   * @param userProfile : user profile to update
-   * @param following : following to add
+   * @param userProfile : the user profile from which we remove a follower
+   * @param follower : the user profile of the follower to remove
    */
-  fun addFollowingInDb(userProfile: UserProfile, following: UserProfile) {
-    val updatedProfile = userProfile.copy(following = userProfile.following + following.mail)
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowingProfile = following.copy(followers = following.followers + userProfile.mail)
-    userProfileRepository.updateUserProfile(updatedFollowingProfile)
-  }
-
-  /**
-   * This function removes a follower from the user profile in the database.
-   *
-   * @param userProfile : user profile to update
-   * @param follower : follower to remove
-   */
-  fun removeFollowerInDb(userProfile: UserProfile, follower: UserProfile) {
-    val updatedProfile =
-        userProfile.copy(followers = userProfile.followers.filter { it != follower.mail })
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowerProfile =
-        follower.copy(following = follower.following.filter { it != userProfile.mail })
-    userProfileRepository.updateUserProfile(updatedFollowerProfile)
-  }
-
-  /**
-   * This function removes a following from the user profile in the database.
-   *
-   * @param userProfile : user profile to update
-   * @param following : following to remove
-   */
-  fun removeFollowingInDb(userProfile: UserProfile, following: UserProfile) {
-    val updatedProfile =
-        userProfile.copy(following = userProfile.following.filter { it != following.mail })
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowingProfile =
-        following.copy(followers = following.followers.filter { it != userProfile.mail })
-    userProfileRepository.updateUserProfile(updatedFollowingProfile)
+  fun removeFollower(userProfile: UserProfile, follower: UserProfile) {
+    val updatedUserProfile = userProfile.copy(followers = userProfile.followers - follower.mail)
+    val updatedFollower = follower.copy(following = follower.following - userProfile.mail)
+    userProfileRepository.updateUserProfile(userProfile)
+    userProfileRepository.updateUserProfile(follower)
   }
 
   /**


### PR DESCRIPTION
Issue #119 is addressed by this pull request, which incorporates the UI for the profile editing window `UserProfileEditScreen.kt` based on the Figma design. Users can now edit various details such as username, name, surname, email, date of birth, and profile picture. Text fields are set up to show a red border when empty, preventing the saving of incomplete profiles. The Material3 DatePicker composable is used for selecting the date of birth. I also added a new file `TopNavigationBar.kt`, which could be useful later.

Remaining tasks include:
- Creating tests
- Checking and cleaning up text inputs for validation
- Integrating the UI into the application's navigation path

<img width="277" alt="CleanShot 2024-04-26 at 00 37 41@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/65d3384a-206a-4b5e-ac40-0d3a430be4b8">
<img width="287" alt="CleanShot 2024-04-26 at 00 37 56@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/b65a453a-c9cd-432c-af81-8b54ff145db0">
<img width="286" alt="CleanShot 2024-04-26 at 00 38 35@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/68cbbcc5-be70-4e92-bcf9-78ef140e6630">
<img width="281" alt="CleanShot 2024-04-26 at 00 38 54@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/6476952d-a1b4-49d1-a70f-f2b40cf20bed">
<img width="283" alt="CleanShot 2024-04-26 at 00 39 05@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/36d1ee81-ccd4-4300-a2d5-b88c8df6316c">
<img width="281" alt="CleanShot 2024-04-26 at 00 39 18@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/e5f86773-6992-4f0a-a17c-070c7a571aa8">






