### PR TITLE
Follower following screens update

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
@@ -15,5 +15,5 @@ class UserProfileFollowersScreen(semanticsProvider: SemanticsNodeInteractionsPro
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
   val followersList: KNode = child { hasTestTag("FollowersList") }
   val removeButton: KNode = child { hasTestTag("RemoveButton") }
-  val followerProfile: KNode = child { hasTestTag("Friend") }
+  val followerProfile: KNode = child { hasTestTag("FriendProfile") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
@@ -15,5 +15,5 @@ class UserProfileFollowingScreen(semanticsProvider: SemanticsNodeInteractionsPro
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
   val removeButton: KNode = child { hasTestTag("RemoveButton") }
   val followingList: KNode = child { hasTestTag("FollowingList") }
-  val followingProfile: KNode = child { hasTestTag("Friend") }
+  val followingProfile: KNode = child { hasTestTag("FriendProfile") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/MockUserList.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/MockUserList.kt
@@ -1,35 +1,88 @@
 package com.example.triptracker.userProfile
 
 import com.example.triptracker.model.profile.UserProfile
-import java.util.Date
 
 class MockUserList {
   private val mockUser1 =
       UserProfile(
-          "1",
-          "Alice",
-          "Smith",
-          Date(2021, 1, 1),
-          "AliceS",
-          "stupid-image-url.com",
-          emptyList(),
+          "schifferlitheo@gmail.com",
+          "Theo",
+          "Schifferli",
+          "15-October-1946",
+          "Tete la malice",
+          "https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS5n-VN2sv2jYgbMF3kVQWkYZQtdlQzje7_-9SYrgFe6w6gUQmL",
+          listOf("cleorenaud38@gmail.com"),
           emptyList())
 
   private val mockUser2 =
-      UserProfile("2", "Bob", "Johnson", Date(2021, 1, 1), "BobJ", null, emptyList(), emptyList())
+      UserProfile(
+          "barghornjeremy@gmail.com",
+          "Jeremy",
+          "Barghorn",
+          "02-April-1939",
+          "GEHREMY",
+          "https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQKS6BRrbH2Pj2QZeMJX_EVsnQcO89myNj1cxHeh2KRLMiamzmL",
+          emptyList(),
+          emptyList())
 
   private val mockUser3 =
       UserProfile(
-          "3",
-          "Charlie",
-          "Brown",
-          Date(2021, 1, 1),
-          "CharlieB",
-          null,
-          listOf(mockUser1.mail, mockUser2.mail),
-          listOf(mockUser1.mail, mockUser2.mail))
+          "polfuentescam@gmail.com",
+          "Pol",
+          "Fuentes",
+          "27-September-1922",
+          "Polfuegoooo",
+          "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Maradona-Mundial_86_con_la_copa.JPG/1200px-Maradona-Mundial_86_con_la_copa.JPG",
+          emptyList(),
+          emptyList())
 
-  private val mockUsers = listOf(mockUser1, mockUser2, mockUser3)
+  private val mockUser4 =
+      UserProfile(
+          "leopold.galhaud@gmail.com",
+          "Leopold",
+          "Galhaud",
+          "20-December-2017",
+          "LeopoldinhoDoBrazil",
+          "https://encrypted-tbn0.gstatic.com/licensed-image?q=tbn:ANd9GcRviVquGNsci2DsyGkO0Wf8vlR9m_L0mT2jskinyr7YD6L3CKw_kO6Vdv0D7gFmmFena5SNPDdB0J9R6x8",
+          emptyList(),
+          emptyList())
+
+  private val mockUser5 =
+      UserProfile(
+          "misentaloic@gmail.com",
+          "Loic",
+          "Misenta",
+          "10-December-1936",
+          "Lomimi",
+          "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcRrfhlD13rGYJRmde04FRLNn2AT3uApwbvOcEfa5pAdMkQA3q8w",
+          emptyList(),
+          emptyList())
+
+  private val mockUser6 =
+      UserProfile(
+          "chaverotjrmy7@gmail.com",
+          "Jeremy",
+          "Chaverot",
+          "17-November-1948",
+          "JeremyyyTheTigerKing",
+          "https://cloudfront-us-east-1.images.arcpublishing.com/advancelocal/6AREHOEFLBGB3EHADZJ4AQCD4A.jpg",
+          emptyList(),
+          emptyList())
+
+  private val mockUser7 =
+      UserProfile(
+          mail = "cleorenaud38@gmail.com",
+          name = "Cleo",
+          surname = "Renaud",
+          birthdate = "08-February-2004",
+          username = "Cleoooo",
+          profileImageUrl =
+              "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+          followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+          following = emptyList())
+
+  private val mockUsers =
+      listOf(mockUser1, mockUser2, mockUser3, mockUser4, mockUser5, mockUser6, mockUser7)
 
   fun getUserProfiles(): List<UserProfile> {
     return mockUsers
@@ -37,6 +90,6 @@ class MockUserList {
 
   fun getNewMockUser(): UserProfile {
     return UserProfile(
-        "4", "David", "Doe", Date(2021, 1, 1), "DavidD", null, emptyList(), emptyList())
+        "4", "David", "Doe", "08-February-2021", "DavidD", null, emptyList(), emptyList())
   }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileListTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileListTest.kt
@@ -3,14 +3,13 @@ package com.example.triptracker.userProfile
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.model.profile.UserProfileList
-import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class UserProfileListTest {
-  private val date1 = Date(2021, 1, 1)
+  private val date1 = "08-February-2021"
 
   private val userProfileList1 = UserProfileList(listOf())
   private val userProfileList2 =
@@ -21,15 +20,19 @@ class UserProfileListTest {
                   name = "Alice",
                   surname = "Smith",
                   birthdate = date1,
-                  pseudo = "AliceS"),
+                  username = "AliceS"),
               UserProfile(
                   mail = "2",
                   name = "Bob",
                   surname = "Johnson",
                   birthdate = date1,
-                  pseudo = "BobJ"),
+                  username = "BobJ"),
               UserProfile(
-                  mail = "3", name = "Bob", surname = "Brown", birthdate = date1, pseudo = "BobB")))
+                  mail = "3",
+                  name = "Bob",
+                  surname = "Brown",
+                  birthdate = date1,
+                  username = "BobB")))
 
   private val userProfileList3 =
       UserProfileList(
@@ -39,19 +42,19 @@ class UserProfileListTest {
                   name = "Alice",
                   surname = "Smith",
                   birthdate = date1,
-                  pseudo = "AliceS"),
+                  username = "AliceS"),
               UserProfile(
                   mail = "5",
                   name = "Bob",
                   surname = "Johnson",
                   birthdate = date1,
-                  pseudo = "BobJ"),
+                  username = "BobJ"),
               UserProfile(
                   mail = "6",
                   name = "Charlie",
                   surname = "Brown",
                   birthdate = date1,
-                  pseudo = "CharlieB")))
+                  username = "CharlieB")))
 
   // TODO: complete this test
 

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileTest.kt
@@ -2,14 +2,13 @@ package com.example.triptracker.userProfile
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.model.profile.UserProfile
-import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class UserProfileTest {
-  private val date1 = Date(2021, 1, 1)
+  private val date1 = "08-February-2021"
 
   private val userProfile1 =
       UserProfile(
@@ -17,7 +16,7 @@ class UserProfileTest {
           name = "Alice",
           surname = "Smith",
           birthdate = date1,
-          pseudo = "AliceS",
+          username = "AliceS",
           profileImageUrl = "stupid-image-url.com",
           following = emptyList(),
           followers = emptyList())
@@ -28,7 +27,7 @@ class UserProfileTest {
           name = "Bob",
           surname = "Johnson",
           birthdate = date1,
-          pseudo = "BobJ",
+          username = "BobJ",
           profileImageUrl = null,
       )
 
@@ -36,7 +35,7 @@ class UserProfileTest {
       UserProfile(
           mail = "3",
           birthdate = date1,
-          pseudo = "CharlieB",
+          username = "CharlieB",
       )
 
   @Test
@@ -45,7 +44,7 @@ class UserProfileTest {
     assertEquals("Alice", userProfile1.name)
     assertEquals("Smith", userProfile1.surname)
     assertEquals(date1, userProfile1.birthdate)
-    assertEquals("AliceS", userProfile1.pseudo)
+    assertEquals("AliceS", userProfile1.username)
     assertEquals("stupid-image-url.com", userProfile1.profileImageUrl)
     assertEquals(emptyList<UserProfile>(), userProfile1.following)
     assertEquals(emptyList<UserProfile>(), userProfile1.followers)
@@ -57,7 +56,7 @@ class UserProfileTest {
     assertEquals("Bob", userProfile2.name)
     assertEquals("Johnson", userProfile2.surname)
     assertEquals(date1, userProfile2.birthdate)
-    assertEquals("BobJ", userProfile2.pseudo)
+    assertEquals("BobJ", userProfile2.username)
     assertEquals(null, userProfile2.profileImageUrl)
     assertEquals(emptyList<UserProfile>(), userProfile2.following)
     assertEquals(emptyList<UserProfile>(), userProfile2.followers)
@@ -69,7 +68,7 @@ class UserProfileTest {
     assertEquals("", userProfile3.name)
     assertEquals("", userProfile3.surname)
     assertEquals(date1, userProfile3.birthdate)
-    assertEquals("CharlieB", userProfile3.pseudo)
+    assertEquals("CharlieB", userProfile3.username)
     assertEquals(null, userProfile3.profileImageUrl)
     assertEquals(emptyList<UserProfile>(), userProfile3.following)
     assertEquals(emptyList<UserProfile>(), userProfile3.followers)

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileViewModelTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileViewModelTest.kt
@@ -131,7 +131,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val follower = mockList.getUserProfiles()[1]
 
-    mockViewModel.addFollowersInDb(user, follower)
+    mockViewModel.addFollower(user, follower)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }
@@ -148,7 +148,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val following = mockList.getUserProfiles()[1]
 
-    mockViewModel.addFollowingInDb(user, following)
+    mockViewModel.addFollower(following, user)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }
@@ -165,7 +165,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val follower = mockList.getUserProfiles()[1]
 
-    mockViewModel.removeFollowerInDb(user, follower)
+    mockViewModel.removeFollower(user, follower)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }
@@ -182,7 +182,7 @@ class UserProfileViewModelTest {
     val user = mockList.getUserProfiles()[0]
     val following = mockList.getUserProfiles()[1]
 
-    mockViewModel.removeFollowingInDb(user, following)
+    mockViewModel.removeFollower(following, user)
     verify {
       Log.d("FirebaseConnection - UserProfileRepository", "User profile updated successfully")
     }

--- a/app/src/main/java/com/example/triptracker/model/profile/UserProfile.kt
+++ b/app/src/main/java/com/example/triptracker/model/profile/UserProfile.kt
@@ -1,7 +1,5 @@
 package com.example.triptracker.model.profile
 
-import java.util.Date
-
 /**
  * This data class represents a user's profile information.
  *
@@ -9,7 +7,7 @@ import java.util.Date
  * @property name : first name of the user. (Defaults: empty string)
  * @property surname : last name of the user. (Defaults: empty string)
  * @property birthdate : user's date of birth.
- * @property pseudo : nickname or pseudonym chosen by the user.
+ * @property username : nickname or pseudonym chosen by the user.
  * @property profileImageUrl : optional URL to the user's profile image. (Defaults: null)
  * @property followers : list of user's followers' email. (Defaults: empty list)
  * @property following : list of user's following's email. (Defaults: empty list)
@@ -18,8 +16,8 @@ data class UserProfile(
     val mail: String,
     val name: String = "",
     val surname: String = "",
-    val birthdate: Date,
-    val pseudo: String,
+    val birthdate: String = "",
+    val username: String = "",
     val profileImageUrl: String? = null,
     val followers: List<String> = emptyList(),
     val following: List<String> = emptyList()

--- a/app/src/main/java/com/example/triptracker/model/profile/UserProfileList.kt
+++ b/app/src/main/java/com/example/triptracker/model/profile/UserProfileList.kt
@@ -30,7 +30,7 @@ data class UserProfileList(private var userProfileList: List<UserProfile>) {
    * @param userProfile : user's profile to add
    */
   fun addUserProfile(userProfile: UserProfile) {
-    userProfileList = userProfileList + userProfile
+    this.userProfileList += userProfile
   }
 
   /**
@@ -43,7 +43,7 @@ data class UserProfileList(private var userProfileList: List<UserProfile>) {
     return userProfileList.filter {
       it.name.contains(task, ignoreCase = true) ||
           it.surname.contains(task, ignoreCase = true) ||
-          it.pseudo.contains(task, ignoreCase = true)
+          it.username.contains(task, ignoreCase = true)
     }
   }
 

--- a/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
@@ -5,7 +5,6 @@ import com.example.triptracker.model.profile.UserProfile
 import com.google.firebase.Firebase
 import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.firestore
-import java.util.Date
 
 /**
  * Repository for the UserProfile class This class is responsible for handling the data operations
@@ -67,7 +66,7 @@ open class UserProfileRepository {
                     document.id,
                     document.data?.get("name") as String,
                     document.data?.get("surname") as String,
-                    document.data?.get("birthdate") as Date,
+                    document.data?.get("birthdate") as String,
                     document.data?.get("pseudo") as String,
                     document.data?.get("profileImageUrl") as String)
           } else {
@@ -91,7 +90,7 @@ open class UserProfileRepository {
               document.id,
               document.data["name"] as String,
               document.data["surname"] as String,
-              document.data["birthdate"] as Date,
+              document.data["birthdate"] as String,
               document.data["pseudo"] as String,
               document.data["profileImageUrl"] as String)
 

--- a/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
@@ -72,62 +72,7 @@ fun FriendListView(
               "Tete la malice",
               "https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS5n-VN2sv2jYgbMF3kVQWkYZQtdlQzje7_-9SYrgFe6w6gUQmL",
               listOf("cleorenaud38@gmail.com"),
-              emptyList()),
-          UserProfile(
-              "barghornjeremy@gmail.com",
-              "Jeremy",
-              "Barghorn",
-              "02-April-1939",
-              "GEHREMY",
-              "https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQKS6BRrbH2Pj2QZeMJX_EVsnQcO89myNj1cxHeh2KRLMiamzmL",
-              emptyList(),
-              emptyList()),
-          UserProfile(
-              "polfuentescam@gmail.com",
-              "Pol",
-              "Fuentes",
-              "27-September-1922",
-              "Polfuegoooo",
-              "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Maradona-Mundial_86_con_la_copa.JPG/1200px-Maradona-Mundial_86_con_la_copa.JPG",
-              emptyList(),
-              emptyList()),
-          UserProfile(
-              "leopold.galhaud@gmail.com",
-              "Leopold",
-              "Galhaud",
-              "20-December-2017",
-              "LeopoldinhoDoBrazil",
-              "https://encrypted-tbn0.gstatic.com/licensed-image?q=tbn:ANd9GcRviVquGNsci2DsyGkO0Wf8vlR9m_L0mT2jskinyr7YD6L3CKw_kO6Vdv0D7gFmmFena5SNPDdB0J9R6x8",
-              emptyList(),
-              emptyList()),
-          UserProfile(
-              "misentaloic@gmail.com",
-              "Loic",
-              "Misenta",
-              "10-December-1936",
-              "Lomimi",
-              "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcRrfhlD13rGYJRmde04FRLNn2AT3uApwbvOcEfa5pAdMkQA3q8w",
-              emptyList(),
-              emptyList()),
-          UserProfile(
-              "chaverotjrmy7@gmail.com",
-              "Jeremy",
-              "Chaverot",
-              "17-November-1948",
-              "JeremyyyTheTigerKing",
-              "https://cloudfront-us-east-1.images.arcpublishing.com/advancelocal/6AREHOEFLBGB3EHADZJ4AQCD4A.jpg",
-              emptyList(),
-              emptyList()),
-          UserProfile(
-              mail = "cleorenaud38@gmail.com",
-              name = "Cleo",
-              surname = "Renaud",
-              birthdate = "08-February-2004",
-              username = "Cleoooo",
-              profileImageUrl =
-                  "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
-              followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
-              following = emptyList()))
+              emptyList()))
 
   // Display the list of user's profiles
   LazyColumn(

--- a/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
@@ -1,15 +1,21 @@
 package com.example.triptracker.view.profile
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -20,19 +26,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.rememberAsyncImagePainter
 import com.example.triptracker.R
 import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.view.theme.md_theme_dark_gray
+import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
-import com.example.triptracker.view.theme.md_theme_light_secondaryContainer
+import com.example.triptracker.view.theme.md_theme_light_onPrimary
+import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.UserProfileViewModel
 
 /**
@@ -48,68 +61,186 @@ fun FriendListView(
     userProfile: UserProfile,
     followers: Boolean,
 ) {
+  // TODO: Remove this hardcoded list of friends
   val friends =
-      if (followers) {
-        userProfile.followers.map { mail -> userProfileViewModel.getUserProfileFromDb(mail)!! }
-      } else {
-        userProfile.following.map { mail -> userProfileViewModel.getUserProfileFromDb(mail)!! }
-      }
+      listOf(
+          UserProfile(
+              "schifferlitheo@gmail.com",
+              "Theo",
+              "Schifferli",
+              "15-October-1946",
+              "Tete la malice",
+              "https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS5n-VN2sv2jYgbMF3kVQWkYZQtdlQzje7_-9SYrgFe6w6gUQmL",
+              listOf("cleorenaud38@gmail.com"),
+              emptyList()),
+          UserProfile(
+              "barghornjeremy@gmail.com",
+              "Jeremy",
+              "Barghorn",
+              "02-April-1939",
+              "GEHREMY",
+              "https://encrypted-tbn2.gstatic.com/images?q=tbn:ANd9GcQKS6BRrbH2Pj2QZeMJX_EVsnQcO89myNj1cxHeh2KRLMiamzmL",
+              emptyList(),
+              emptyList()),
+          UserProfile(
+              "polfuentescam@gmail.com",
+              "Pol",
+              "Fuentes",
+              "27-September-1922",
+              "Polfuegoooo",
+              "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2c/Maradona-Mundial_86_con_la_copa.JPG/1200px-Maradona-Mundial_86_con_la_copa.JPG",
+              emptyList(),
+              emptyList()),
+          UserProfile(
+              "leopold.galhaud@gmail.com",
+              "Leopold",
+              "Galhaud",
+              "20-December-2017",
+              "LeopoldinhoDoBrazil",
+              "https://encrypted-tbn0.gstatic.com/licensed-image?q=tbn:ANd9GcRviVquGNsci2DsyGkO0Wf8vlR9m_L0mT2jskinyr7YD6L3CKw_kO6Vdv0D7gFmmFena5SNPDdB0J9R6x8",
+              emptyList(),
+              emptyList()),
+          UserProfile(
+              "misentaloic@gmail.com",
+              "Loic",
+              "Misenta",
+              "10-December-1936",
+              "Lomimi",
+              "https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcRrfhlD13rGYJRmde04FRLNn2AT3uApwbvOcEfa5pAdMkQA3q8w",
+              emptyList(),
+              emptyList()),
+          UserProfile(
+              "chaverotjrmy7@gmail.com",
+              "Jeremy",
+              "Chaverot",
+              "17-November-1948",
+              "JeremyyyTheTigerKing",
+              "https://cloudfront-us-east-1.images.arcpublishing.com/advancelocal/6AREHOEFLBGB3EHADZJ4AQCD4A.jpg",
+              emptyList(),
+              emptyList()),
+          UserProfile(
+              mail = "cleorenaud38@gmail.com",
+              name = "Cleo",
+              surname = "Renaud",
+              birthdate = "08-February-2004",
+              username = "Cleoooo",
+              profileImageUrl =
+                  "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+              followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+              following = emptyList()))
 
   // Display the list of user's profiles
   LazyColumn(
-      modifier = Modifier.fillMaxWidth().padding(15.dp).testTag("FriendListScreen"),
-  ) {
-    items(friends) { friend ->
-      // Display the user's profile
-      Row(
-          modifier = Modifier.height(70.dp).fillMaxWidth(),
-      ) {
-        Column(modifier = Modifier.fillMaxHeight()) {
-          Text(
-              text = friend.pseudo,
-              style =
-                  TextStyle(
-                      fontSize = 20.sp,
-                      lineHeight = 16.sp,
-                      fontFamily = FontFamily(Font(R.font.montserrat)),
-                      fontWeight = FontWeight(700),
-                      color = Color.Black,
-                      textAlign = TextAlign.Right,
-                      letterSpacing = 0.5.sp),
-          )
-          Row(
-              // modifier = Modifier.fillMaxWidth(),
-              verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = friend.name,
-                    style = AppTypography.secondaryTitleStyle,
-                )
-                Spacer(modifier = Modifier.width(2.dp))
-                Text(
-                    text = friend.surname,
-                    style = AppTypography.secondaryTitleStyle,
-                )
-              }
-        }
-        Column(
-            modifier = Modifier.fillMaxWidth().testTag("Friend"),
-            horizontalAlignment = Alignment.End) {
-              if (followers) {
-                // Display the remove follower button
-                RemoveFriendButton(
-                    remove = { userProfileViewModel.removeFollowerInDb(userProfile, friend) },
-                    undoRemove = { userProfileViewModel.addFollowersInDb(userProfile, friend) },
-                    followers = true)
-              } else {
-                RemoveFriendButton(
-                    remove = { userProfileViewModel.removeFollowingInDb(userProfile, friend) },
-                    undoRemove = { userProfileViewModel.addFollowingInDb(userProfile, friend) },
-                    followers = false)
-              }
+      modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(15.dp).testTag("FriendListScreen"),
+      verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        if (friends.isEmpty()) {
+          item {
+            Text(
+                text = if (followers) "No followers" else "Not following anyone",
+                style =
+                    TextStyle(
+                        fontSize = 20.sp,
+                        lineHeight = 16.sp,
+                        fontFamily = FontFamily(Font(R.font.montserrat)),
+                        fontWeight = FontWeight(700),
+                        color = Color.Black,
+                        textAlign = TextAlign.Center,
+                        letterSpacing = 0.5.sp),
+                modifier = Modifier.fillMaxWidth().padding(10.dp))
+          }
+        } else {
+          items(friends) { friend ->
+            if (friend != null) {
+              // Display the user's profile
+              Box(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .height(105.dp)
+                          .background(md_theme_light_dark, shape = RoundedCornerShape(35.dp))
+                          .testTag("FriendProfile"),
+                  contentAlignment = Alignment.Center) {
+                    Row(
+                        modifier = Modifier.fillMaxHeight().padding(start = 20.dp, end = 20.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
+                          // Image painter for loading from a URL
+                          val imagePainter =
+                              rememberAsyncImagePainter(model = friend.profileImageUrl)
+
+                          Image(
+                              painter = imagePainter,
+                              contentDescription = "${userProfile.username}'s profile picture",
+                              contentScale = ContentScale.Crop,
+                              modifier =
+                                  Modifier.size(62.dp)
+                                      .clip(RoundedCornerShape(50))
+                                      .align(Alignment.CenterVertically))
+                          Column(
+                              modifier = Modifier.fillMaxHeight().padding(start = 15.dp),
+                              verticalArrangement = Arrangement.Center) {
+                                Text(
+                                    text = friend.username,
+                                    style =
+                                        TextStyle(
+                                            fontSize = 16.sp,
+                                            lineHeight = 16.sp,
+                                            fontFamily = FontFamily(Font(R.font.montserrat)),
+                                            fontWeight = FontWeight(600),
+                                            color = Color.White,
+                                            textAlign = TextAlign.Left,
+                                            letterSpacing = 0.5.sp),
+                                    overflow = TextOverflow.Ellipsis,
+                                    maxLines = 1)
+                                Row(
+                                    // modifier = Modifier.fillMaxWidth(),
+                                    //                              verticalAlignment =
+                                    // Alignment.CenterVertically
+                                    ) {
+                                      Text(
+                                          text = "${friend.name} ${friend.surname}",
+                                          style =
+                                              TextStyle(
+                                                  fontSize = 14.sp,
+                                                  lineHeight = 16.sp,
+                                                  fontFamily = FontFamily(Font(R.font.montserrat)),
+                                                  fontWeight = FontWeight(600),
+                                                  color = md_theme_dark_gray,
+                                                  textAlign = TextAlign.Left,
+                                                  letterSpacing = 0.5.sp),
+                                          overflow = TextOverflow.Ellipsis,
+                                          maxLines = 1)
+                                    }
+                              }
+                          Column(
+                              modifier = Modifier.fillMaxWidth().width(95.dp),
+                              horizontalAlignment = Alignment.End,
+                          ) {
+                            if (followers) {
+                              // Display the remove follower button
+                              RemoveFriendButton(
+                                  remove = {
+                                    userProfileViewModel.removeFollower(userProfile, friend)
+                                  },
+                                  undoRemove = {
+                                    userProfileViewModel.addFollower(userProfile, friend)
+                                  },
+                                  followers = true)
+                            } else {
+                              RemoveFriendButton(
+                                  remove = {
+                                    userProfileViewModel.removeFollower(friend, userProfile)
+                                  },
+                                  undoRemove = {
+                                    userProfileViewModel.addFollower(friend, userProfile)
+                                  },
+                                  followers = false)
+                            }
+                          }
+                        }
+                  }
             }
+          }
+        }
       }
-    }
-  }
 }
 
 /** This composable function displays a button to remove a follower. */
@@ -133,17 +264,18 @@ fun RemoveFriendButton(remove: () -> Unit, undoRemove: () -> Unit, followers: Bo
       colors =
           if (!isRemoved) {
             ButtonDefaults.buttonColors(
-                containerColor = md_theme_light_dark,
-                contentColor = md_theme_light_secondaryContainer)
+                containerColor = md_theme_orange, contentColor = md_theme_light_onPrimary)
           } else {
             ButtonDefaults.buttonColors(
-                containerColor = md_theme_light_secondaryContainer,
-                contentColor = md_theme_light_dark)
+                containerColor = md_theme_grey, contentColor = md_theme_light_onPrimary)
           },
-      modifier =
-          Modifier.height(40.dp)
-              .width(120.dp)
-              .testTag("RemoveButton")) { // .testTag(if (isRemoved) { "RemoveButton" } else {
+      modifier = Modifier.height(40.dp).width(95.dp).testTag("RemoveButton"),
+      contentPadding =
+          PaddingValues( // Reduce the padding around the text
+              start = 2.dp,
+              top = 4.dp,
+              end = 2.dp,
+              bottom = 4.dp)) { // .testTag(if (isRemoved) { "RemoveButton" } else {
         // "UndoButton" })) {
         Text(
             text =
@@ -152,44 +284,16 @@ fun RemoveFriendButton(remove: () -> Unit, undoRemove: () -> Unit, followers: Bo
                 if (!followers && isRemoved) "Follow" // when displaying removed following
                 else if (!followers && !isRemoved) "Following" // when displaying following
                 else if (followers && isRemoved) "Undo" // when displaying removed followers
-                else "Remove" // when displaying followers
-            )
+                else "Remove", // when displaying followers
+            modifier = Modifier.fillMaxWidth(),
+            style =
+                TextStyle(
+                    fontSize = 12.sp,
+                    lineHeight = 12.sp,
+                    fontFamily = FontFamily(Font(R.font.montserrat)),
+                    fontWeight = FontWeight(500),
+                    color = Color.White,
+                    textAlign = TextAlign.Center,
+                    letterSpacing = 0.5.sp))
       }
 }
-
-// @Preview
-// @Composable
-// fun FriendListViewPreview() {
-//    val mockUser1 =
-//        UserProfile(
-//            "1",
-//            "Alice",
-//            "Smith",
-//            Date(2021, 1, 1),
-//            "AliceS",
-//            "stupid-image-url.com",
-//            emptyList(),
-//            emptyList()
-//        )
-//
-//    val mockUser2 =
-//        UserProfile("2", "Bob", "Johnson", Date(2021, 1, 1), "BobJ", null, emptyList(),
-// emptyList())
-//
-//    val mockUser3 =
-//        UserProfile(
-//            "3",
-//            "Charlie",
-//            "Brown",
-//            Date(2021, 1, 1),
-//            "CharlieB",
-//            null,
-//            listOf(mockUser1, mockUser2),
-//            listOf(mockUser1, mockUser2)
-//        )
-//
-//    val mockUsers = listOf(mockUser1, mockUser2, mockUser3)
-//
-//    FriendListView(userProfileViewModel = UserProfileViewModel(), userProfile = mockUser3,
-// followers = true)
-// }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowers.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowers.kt
@@ -75,8 +75,6 @@ fun UserProfileFollowers(
                             textAlign = TextAlign.Center,
                             letterSpacing = 0.5.sp,
                         ),
-                    // modifier = Modifier.weight(1f)
-                    // .padding(horizontal = 16.dp)
                     modifier =
                         Modifier.width(250.dp)
                             .height(37.dp)
@@ -94,3 +92,30 @@ fun UserProfileFollowers(
         }
       }
 }
+
+//// TODO: remove this preview
+// @Preview(showBackground = true)
+// @Composable
+// fun UserProfileFollowersPreview() {
+//    val viewModel = UserProfileViewModel()
+//
+//    //val list = viewModel.userProfileList.value
+//    //val profile = viewModel.getUserProfile("cleorenaud38@gmail.com")
+//
+//    val navController = rememberNavController()
+//    val navigation = remember(navController) { Navigation(navController) }
+//
+//    val mockUser1 = UserProfile(
+//        mail = "cleorenaud38@gmail.com",
+//        name = "Cleo",
+//        surname = "Renaud",
+//        birthdate = "08-February-2004",
+//        username = "Cleoooo",
+//        profileImageUrl =
+// "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+//        followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+//        following = emptyList()
+//    )
+//
+//    UserProfileFollowers(navigation, viewModel, mockUser1)
+// }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowing.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowing.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -28,10 +27,8 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.compose.rememberNavController
 import com.example.triptracker.R
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.Navigation
@@ -96,29 +93,30 @@ fun UserProfileFollowing(
       }
 }
 
-// TODO: remove this preview
-@Preview(showBackground = true)
-@Composable
-fun UserProfileFollowingPreview() {
-  val viewModel = UserProfileViewModel()
-
-  // val list = viewModel.userProfileList.value
-  // val profile = viewModel.getUserProfile("cleorenaud38@gmail.com")
-
-  val navController = rememberNavController()
-  val navigation = remember(navController) { Navigation(navController) }
-
-  val mockUser1 =
-      UserProfile(
-          mail = "cleorenaud38@gmail.com",
-          name = "Cleo",
-          surname = "Renaud",
-          birthdate = "08-February-2004",
-          username = "Cleoooo",
-          profileImageUrl =
-              "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
-          followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
-          following = emptyList())
-
-  UserProfileFollowing(navigation, viewModel, mockUser1)
-}
+//// TODO: remove this preview
+// @Preview(showBackground = true)
+// @Composable
+// fun UserProfileFollowingPreview() {
+//  val viewModel = UserProfileViewModel()
+//
+//  // val list = viewModel.userProfileList.value
+//  // val profile = viewModel.getUserProfile("cleorenaud38@gmail.com")
+//
+//  val navController = rememberNavController()
+//  val navigation = remember(navController) { Navigation(navController) }
+//
+//  val mockUser1 =
+//      UserProfile(
+//          mail = "cleorenaud38@gmail.com",
+//          name = "Cleo",
+//          surname = "Renaud",
+//          birthdate = "08-February-2004",
+//          username = "Cleoooo",
+//          profileImageUrl =
+//
+// "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+//          followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+//          following = emptyList())
+//
+//  UserProfileFollowing(navigation, viewModel, mockUser1)
+// }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowing.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileFollowing.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,8 +28,10 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.rememberNavController
 import com.example.triptracker.R
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.Navigation
@@ -75,7 +78,11 @@ fun UserProfileFollowing(
                             textAlign = TextAlign.Center,
                             letterSpacing = 0.5.sp,
                         ),
-                    modifier = Modifier.weight(1f).testTag("FollowingTitle"))
+                    modifier =
+                        Modifier.width(250.dp)
+                            .height(37.dp)
+                            .padding(5.dp)
+                            .testTag("FollowingTitle"))
                 Box(modifier = Modifier.size(60.dp))
               }
             }
@@ -87,4 +94,31 @@ fun UserProfileFollowing(
           FriendListView(userProfileViewModel, userProfile, false)
         }
       }
+}
+
+// TODO: remove this preview
+@Preview(showBackground = true)
+@Composable
+fun UserProfileFollowingPreview() {
+  val viewModel = UserProfileViewModel()
+
+  // val list = viewModel.userProfileList.value
+  // val profile = viewModel.getUserProfile("cleorenaud38@gmail.com")
+
+  val navController = rememberNavController()
+  val navigation = remember(navController) { Navigation(navController) }
+
+  val mockUser1 =
+      UserProfile(
+          mail = "cleorenaud38@gmail.com",
+          name = "Cleo",
+          surname = "Renaud",
+          birthdate = "08-February-2004",
+          username = "Cleoooo",
+          profileImageUrl =
+              "https://hips.hearstapps.com/hmg-prod/images/portrait-of-a-red-fluffy-cat-with-big-eyes-in-royalty-free-image-1701455126.jpg",
+          followers = listOf("schifferlitheo@gmail.com", "barghornjeremy@gmail.com"),
+          following = emptyList())
+
+  UserProfileFollowing(navigation, viewModel, mockUser1)
 }

--- a/app/src/main/java/com/example/triptracker/viewmodel/UserProfileViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/UserProfileViewModel.kt
@@ -53,63 +53,29 @@ class UserProfileViewModel(
   }
 
   /**
-   * This function adds new followers to the user profile in the database.
+   * Function that add the follower to the user profile
    *
-   * @param userProfile : user profile to update
-   * @param follower : follower to add
+   * @param userProfile : the user profile to which we add a follower
+   * @param follower : the user profile of the follower to add
    */
-  fun addFollowersInDb(userProfile: UserProfile, follower: UserProfile) {
-    val updatedProfile = userProfile.copy(followers = userProfile.followers + follower.mail)
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowerProfile = follower.copy(following = follower.following + userProfile.mail)
-    userProfileRepository.updateUserProfile(updatedFollowerProfile)
+  fun addFollower(userProfile: UserProfile, follower: UserProfile) {
+    val updatedUserProfile = userProfile.copy(followers = userProfile.followers + follower.mail)
+    val updatedFollower = follower.copy(following = follower.following + userProfile.mail)
+    userProfileRepository.updateUserProfile(updatedUserProfile)
+    userProfileRepository.updateUserProfile(updatedFollower)
   }
 
   /**
-   * This function adds new following to the user profile in the database.
+   * Function that remove the follower from the user profile
    *
-   * @param userProfile : user profile to update
-   * @param following : following to add
+   * @param userProfile : the user profile from which we remove a follower
+   * @param follower : the user profile of the follower to remove
    */
-  fun addFollowingInDb(userProfile: UserProfile, following: UserProfile) {
-    val updatedProfile = userProfile.copy(following = userProfile.following + following.mail)
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowingProfile = following.copy(followers = following.followers + userProfile.mail)
-    userProfileRepository.updateUserProfile(updatedFollowingProfile)
-  }
-
-  /**
-   * This function removes a follower from the user profile in the database.
-   *
-   * @param userProfile : user profile to update
-   * @param follower : follower to remove
-   */
-  fun removeFollowerInDb(userProfile: UserProfile, follower: UserProfile) {
-    val updatedProfile =
-        userProfile.copy(followers = userProfile.followers.filter { it != follower.mail })
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowerProfile =
-        follower.copy(following = follower.following.filter { it != userProfile.mail })
-    userProfileRepository.updateUserProfile(updatedFollowerProfile)
-  }
-
-  /**
-   * This function removes a following from the user profile in the database.
-   *
-   * @param userProfile : user profile to update
-   * @param following : following to remove
-   */
-  fun removeFollowingInDb(userProfile: UserProfile, following: UserProfile) {
-    val updatedProfile =
-        userProfile.copy(following = userProfile.following.filter { it != following.mail })
-    userProfileRepository.updateUserProfile(updatedProfile)
-
-    val updatedFollowingProfile =
-        following.copy(followers = following.followers.filter { it != userProfile.mail })
-    userProfileRepository.updateUserProfile(updatedFollowingProfile)
+  fun removeFollower(userProfile: UserProfile, follower: UserProfile) {
+    val updatedUserProfile = userProfile.copy(followers = userProfile.followers - follower.mail)
+    val updatedFollower = follower.copy(following = follower.following - userProfile.mail)
+    userProfileRepository.updateUserProfile(userProfile)
+    userProfileRepository.updateUserProfile(follower)
   }
 
   /**


### PR DESCRIPTION
The followers and following now match the Figma. (Another pull request will be done to add the search bar to both views) :
![Screenshot 2024-04-26 at 10 37 34](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73248361/5ea82f9c-0a69-4966-aa5b-25d8bbabe18c)


I also refactored some parts of the UserProfile: 
- The birthday is now stored as a string (and will be converted to a LocalDate when necessary)
- The pseudo is now renamed to username

The functions in the UserProfileViewModel handling the followers/following have been changed. There are now only two functions :
- addFollower(userProfile, follower) : function to call when userProfile starts following follower
- removeFollower(userProfile, follower) : function to call when userProfile remove follower from it's followers
The reason for this change is that it avoid useless code duplication as addFollowing(userProfile, following) was the same as doing addFollower(following, userProfile)