### PR TITLE
Smoothing maps and record

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
@@ -60,9 +60,15 @@ class AddSpotTest {
         performClick()
       }
 
-      pictures { assertIsDisplayed() }
+      pictures {
+        performScrollTo()
+        assertIsDisplayed()
+      }
 
-      saveButton { assertIsDisplayed() }
+      saveButton {
+        performScrollTo()
+        assertIsDisplayed()
+      }
     }
   }
 
@@ -90,7 +96,7 @@ class AddSpotTest {
 
         performTextClearance()
 
-        performTextInput("EPFL")
+        performTextInput("ecole polytechnique federale")
         composeTestRule.onNodeWithTag("LocationDropDown").performClick()
       }
       runBlocking { delay(2000) }
@@ -155,6 +161,7 @@ class AddSpotTest {
       }
 
       saveButton {
+        performScrollTo()
         assertIsDisplayed()
         performClick()
       }

--- a/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
@@ -93,7 +93,7 @@ class AddSpotTest {
         performTextInput("EPFL")
         composeTestRule.onNodeWithTag("LocationDropDown").performClick()
       }
-      runBlocking { delay(1000) }
+      runBlocking { delay(2000) }
       locationText {
         assertIsDisplayed()
         assertTextContains("École Polytechnique Fédérale de Lausanne", substring = true)

--- a/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
@@ -50,7 +50,11 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
 
     composeTestRule.setContent {
-      MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
+      MapOverview(
+          mapViewModel = mockViewModel,
+          context = appContext,
+          navigation = mockNavigation,
+          selectedId = "")
     }
 
     // Verify that the dependencies are properly initialized
@@ -70,7 +74,8 @@ class MapOverviewTest : TestCase() {
           mapViewModel = mockViewModel,
           context = appContext,
           navigation = mockNavigation,
-          checkLocationPermission = false)
+          checkLocationPermission = false,
+          selectedId = "")
     }
 
     // Verify that the map is not shown

--- a/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
@@ -8,9 +8,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import com.example.triptracker.itinerary.MockItineraryList
+import com.example.triptracker.model.itinerary.ItineraryList
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.map.MapOverview
-import com.example.triptracker.view.map.MapOverviewPreview
 import com.example.triptracker.viewmodel.MapViewModel
 import com.google.android.gms.maps.model.LatLng
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
@@ -48,6 +48,7 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.cityNameState.value } returns "Lyon"
     every { mockViewModel.filteredPathList.value } returns null
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.pathList.value } returns ItineraryList(itineraryList)
 
     composeTestRule.setContent {
       MapOverview(
@@ -75,7 +76,7 @@ class MapOverviewTest : TestCase() {
           context = appContext,
           navigation = mockNavigation,
           checkLocationPermission = false,
-          selectedId = "")
+          selectedId = "1")
     }
 
     // Verify that the map is not shown
@@ -91,6 +92,10 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "") } returns null
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "1") } returns itineraryList[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "2") } returns itineraryList[1]
+    every { mockViewModel.pathList.value } returns ItineraryList(itineraryList)
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
@@ -109,9 +114,18 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "") } returns null
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "1") } returns itineraryList[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "2") } returns itineraryList[1]
+    every { mockViewModel.pathList.value } returns ItineraryList(itineraryList)
 
     composeTestRule.setContent {
-      MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
+      MapOverview(
+          mapViewModel = mockViewModel,
+          context = appContext,
+          navigation = mockNavigation,
+          checkLocationPermission = true,
+          selectedId = "")
     }
 
     // Verify that the dependencies are properly called
@@ -124,11 +138,22 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.cityNameState.value } returns "Lyon"
     every { mockViewModel.filteredPathList.value } returns null
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "") } returns null
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "1") } returns itineraryList[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "2") } returns itineraryList[1]
+    every { mockViewModel.pathList.value } returns ItineraryList(itineraryList)
 
-    composeTestRule.setContent { MapOverviewPreview(mapViewModel = mockViewModel) }
+    composeTestRule.setContent {
+      MapOverview(
+          mapViewModel = mockViewModel,
+          context = appContext,
+          navigation = mockNavigation,
+          checkLocationPermission = false,
+          selectedId = "1")
+    }
 
-    // Verify that the dependencies are properly initialized
-    composeTestRule.onNodeWithTag("MapOverview").assertExists()
+    // Verify that the map is not shown
+    composeTestRule.onNodeWithTag("MapOverview").assertDoesNotExist()
   }
 
   @Test
@@ -137,12 +162,21 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.cityNameState.value } returns "Lyon"
     every { mockViewModel.filteredPathList.value } returns
         mapOf(itineraryList[0] to listOf<LatLng>(LatLng(0.0, 0.0)))
+    every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "") } returns null
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "1") } returns itineraryList[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "2") } returns itineraryList[1]
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
-    every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.pathList.value } returns ItineraryList(itineraryList)
 
     composeTestRule.setContent {
-      MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
+      MapOverview(
+          mapViewModel = mockViewModel,
+          context = appContext,
+          navigation = mockNavigation,
+          checkLocationPermission = true,
+          selectedId = "")
     }
 
     composeTestRule.onNodeWithTag("MapOverview").assertExists()
@@ -161,6 +195,10 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "") } returns null
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "1") } returns itineraryList[0]
+    every { mockViewModel.getPathById(ItineraryList(itineraryList), "2") } returns itineraryList[1]
+    every { mockViewModel.pathList.value } returns ItineraryList(itineraryList)
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)

--- a/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/MapOverviewTest.kt
@@ -48,8 +48,6 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.cityNameState.value } returns "Lyon"
     every { mockViewModel.filteredPathList.value } returns null
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-    every { mockViewModel.displayPopUp.value } returns false
-    every { mockViewModel.displayPicturesPopUp.value } returns false
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
@@ -66,8 +64,6 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.cityNameState.value } returns "Lyon"
     every { mockViewModel.filteredPathList.value } returns null
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-    every { mockViewModel.displayPopUp.value } returns false
-    every { mockViewModel.displayPicturesPopUp.value } returns false
 
     composeTestRule.setContent {
       MapOverview(
@@ -90,8 +86,6 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-    every { mockViewModel.displayPopUp.value } returns false
-    every { mockViewModel.displayPicturesPopUp.value } returns false
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
@@ -110,8 +104,6 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-    every { mockViewModel.displayPopUp.value } returns false
-    every { mockViewModel.displayPicturesPopUp.value } returns false
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
@@ -127,8 +119,6 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.cityNameState.value } returns "Lyon"
     every { mockViewModel.filteredPathList.value } returns null
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-    every { mockViewModel.displayPopUp.value } returns false
-    every { mockViewModel.displayPicturesPopUp.value } returns false
 
     composeTestRule.setContent { MapOverviewPreview(mapViewModel = mockViewModel) }
 
@@ -144,9 +134,7 @@ class MapOverviewTest : TestCase() {
         mapOf(itineraryList[0] to listOf<LatLng>(LatLng(0.0, 0.0)))
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
-    every { mockViewModel.displayPopUp.value } returns true
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-    every { mockViewModel.displayPicturesPopUp.value } returns false
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)
@@ -168,10 +156,6 @@ class MapOverviewTest : TestCase() {
     every { mockViewModel.selectedPolylineState.value } returns
         MapViewModel.SelectedPolyline(itineraryList[0], LatLng(0.0, 0.0))
     every { mockViewModel.selectedPin.value } returns itineraryList[0].pinnedPlaces[0]
-
-    every { mockViewModel.displayPopUp.value } returns false
-
-    every { mockViewModel.displayPicturesPopUp.value } returns true
 
     composeTestRule.setContent {
       MapOverview(mapViewModel = mockViewModel, context = appContext, navigation = mockNavigation)

--- a/app/src/androidTest/java/com/example/triptracker/map/MapPopupTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/MapPopupTest.kt
@@ -55,7 +55,7 @@ class MapPopupTest {
             "description",
             listOf())
 
-    composeTestRule.setContent { PathOverlaySheet(itinerary) }
+    composeTestRule.setContent { PathOverlaySheet(itinerary, onClick = {}) }
 
     // Assertions to check if the UI components are displayed correctly
     composeTestRule.onNodeWithText("Jack's Path").assertIsDisplayed()

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -65,8 +65,6 @@ class MainActivity : ComponentActivity() {
             composable(
                 "MAPS?id={id}", arguments = listOf(navArgument("id") { defaultValue = "" })) {
                     backStackEntry ->
-                  Log.d("MainActivity", backStackEntry.toString())
-                  Log.d("MainActivity", backStackEntry.arguments?.getString("id") ?: "")
                   MapOverview(
                       context = context,
                       navigation = navigation,

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -58,10 +58,12 @@ class MainActivity : ComponentActivity() {
           ) {
             composable(Route.LOGIN) { LoginScreen(navigation) }
             composable(Route.HOME) { HomeScreen(navigation) }
-            composable(Route.MAPS) { MapOverview(context = context, navigation = navigation) }
+//            composable(Route.MAPS) { MapOverview(context = context, navigation = navigation, selectedId = "") }
             composable(Route.MAPS + "/{id}") { backStackEntry ->
               val id = backStackEntry.arguments?.getString("id") ?: ""
-
+              if(id == "null"){
+                MapOverview(context = context, navigation = navigation, selectedId = "")
+              } else
               MapOverview(context = context, navigation = navigation, selectedId = id)
             }
 

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -2,6 +2,7 @@ package com.example.triptracker
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.example.triptracker.navigation.LaunchPermissionRequest
 import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
@@ -58,14 +60,18 @@ class MainActivity : ComponentActivity() {
           ) {
             composable(Route.LOGIN) { LoginScreen(navigation) }
             composable(Route.HOME) { HomeScreen(navigation) }
-//            composable(Route.MAPS) { MapOverview(context = context, navigation = navigation, selectedId = "") }
-            composable(Route.MAPS + "/{id}") { backStackEntry ->
-              val id = backStackEntry.arguments?.getString("id") ?: ""
-              if(id == "null"){
-                MapOverview(context = context, navigation = navigation, selectedId = "")
-              } else
-              MapOverview(context = context, navigation = navigation, selectedId = id)
-            }
+            //            composable(Route.MAPS) { MapOverview(context = context, navigation =
+            // navigation, selectedId = "") }
+            composable(
+                "MAPS?id={id}", arguments = listOf(navArgument("id") { defaultValue = "" })) {
+                    backStackEntry ->
+                  Log.d("MainActivity", backStackEntry.toString())
+                  Log.d("MainActivity", backStackEntry.arguments?.getString("id") ?: "")
+                  MapOverview(
+                      context = context,
+                      navigation = navigation,
+                      selectedId = backStackEntry.arguments?.getString("id") ?: "")
+                }
 
             composable(Route.RECORD) { RecordScreen(context, navigation) }
             composable(Route.PROFILE) { UserProfileOverview(navigation = navigation) }

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -2,7 +2,6 @@ package com.example.triptracker
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -17,12 +17,10 @@ import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.Route
 import com.example.triptracker.view.home.HomeScreen
-import com.example.triptracker.view.map.DEFAULT_LOCATION
 import com.example.triptracker.view.map.MapOverview
 import com.example.triptracker.view.map.RecordScreen
 import com.example.triptracker.view.profile.UserProfileOverview
 import com.example.triptracker.view.theme.TripTrackerTheme
-import com.google.android.gms.maps.model.LatLng
 
 class MainActivity : ComponentActivity() {
 
@@ -61,16 +59,10 @@ class MainActivity : ComponentActivity() {
             composable(Route.LOGIN) { LoginScreen(navigation) }
             composable(Route.HOME) { HomeScreen(navigation) }
             composable(Route.MAPS) { MapOverview(context = context, navigation = navigation) }
-            composable(Route.MAPS + "/{lat}" + "/{lon}") { backStackEntry ->
-              val lat =
-                  backStackEntry.arguments?.getString("lat") ?: DEFAULT_LOCATION.latitude.toString()
-              val lon =
-                  backStackEntry.arguments?.getString("lon")
-                      ?: DEFAULT_LOCATION.longitude.toString()
-              MapOverview(
-                  context = context,
-                  navigation = navigation,
-                  startLocation = LatLng(lat.toDouble(), lon.toDouble()))
+            composable(Route.MAPS + "/{id}") { backStackEntry ->
+              val id = backStackEntry.arguments?.getString("id") ?: ""
+
+              MapOverview(context = context, navigation = navigation, selectedId = id)
             }
 
             composable(Route.RECORD) { RecordScreen(context, navigation) }

--- a/app/src/main/java/com/example/triptracker/model/geocoder/NominatimApi.kt
+++ b/app/src/main/java/com/example/triptracker/model/geocoder/NominatimApi.kt
@@ -198,7 +198,7 @@ class NominatimApi {
 
       val name = json?.get(LocationStrings.NAME)
 
-      Log.d("API RESPONSE", name.toString())
+      //      Log.d("API RESPONSE", name.toString())
 
       if (name == null) {
         callback(LocationErrors.UNKNOWN)

--- a/app/src/main/java/com/example/triptracker/view/Navigation.kt
+++ b/app/src/main/java/com/example/triptracker/view/Navigation.kt
@@ -37,7 +37,7 @@ private val TOP_LEVEL_DESTINATIONS =
     listOf(
         // TopLevelDestination(Route.LOGIN, Icons.Default.List, "Login"),
         TopLevelDestination(Route.HOME, Icons.Outlined.Home, "Home"),
-        TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps"),
+        TopLevelDestination(Route.MAPS + "/null", Icons.Outlined.Place, "Maps"),
         TopLevelDestination(Route.RECORD, Icons.Outlined.RadioButtonChecked, "Record"),
         TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile"),
     )

--- a/app/src/main/java/com/example/triptracker/view/Navigation.kt
+++ b/app/src/main/java/com/example/triptracker/view/Navigation.kt
@@ -55,6 +55,7 @@ class Navigation(val navController: NavHostController) {
   fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
       currentDestination = destination
+      navController.currentBackStackEntry?.arguments?.putString("id", "")
       // Pop up to the start destination of the graph to
       // avoid building up a large stack of destinations
       // on the back stack as users select items

--- a/app/src/main/java/com/example/triptracker/view/Navigation.kt
+++ b/app/src/main/java/com/example/triptracker/view/Navigation.kt
@@ -55,6 +55,7 @@ class Navigation(val navController: NavHostController) {
   fun navigateTo(destination: TopLevelDestination) {
     navController.navigate(destination.route) {
       currentDestination = destination
+      // reset the id when navigating normally so that the state is not saved
       navController.currentBackStackEntry?.arguments?.putString("id", "")
       // Pop up to the start destination of the graph to
       // avoid building up a large stack of destinations
@@ -68,11 +69,12 @@ class Navigation(val navController: NavHostController) {
     }
   }
 
+  // Only use this when navigating to the maps screen
   fun navigateTo(route: String, id: String) {
     Log.d("Navigation", route + id)
     navController.navigate("MAPS?id=$id") {
       currentDestination = getTopLevelDestinations().find { it.route == "maps" }!!
-
+      // set the id when navigating with the map
       navController.currentBackStackEntry?.arguments?.putString("id", id)
       // Pop up to the start destination of the graph to
       // avoid building up a large stack of destinations

--- a/app/src/main/java/com/example/triptracker/view/Navigation.kt
+++ b/app/src/main/java/com/example/triptracker/view/Navigation.kt
@@ -1,5 +1,6 @@
 package com.example.triptracker.view
 
+import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Person
@@ -37,7 +38,7 @@ private val TOP_LEVEL_DESTINATIONS =
     listOf(
         // TopLevelDestination(Route.LOGIN, Icons.Default.List, "Login"),
         TopLevelDestination(Route.HOME, Icons.Outlined.Home, "Home"),
-        TopLevelDestination(Route.MAPS + "/null", Icons.Outlined.Place, "Maps"),
+        TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps"),
         TopLevelDestination(Route.RECORD, Icons.Outlined.RadioButtonChecked, "Record"),
         TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile"),
     )
@@ -63,6 +64,24 @@ class Navigation(val navController: NavHostController) {
       launchSingleTop = true
       // Restore state when reselecting a previously selected item
       restoreState = true
+    }
+  }
+
+  fun navigateTo(route: String, id: String) {
+    Log.d("Navigation", route + id)
+    navController.navigate("MAPS?id=$id") {
+      currentDestination = getTopLevelDestinations().find { it.route == "maps" }!!
+
+      navController.currentBackStackEntry?.arguments?.putString("id", id)
+      // Pop up to the start destination of the graph to
+      // avoid building up a large stack of destinations
+      // on the back stack as users select items
+      popUpTo(navController.graph.findStartDestination().id) { saveState = false }
+      // Avoid multiple copies of the same destination when
+      // reselecting the same item
+      //      launchSingleTop = true
+      // Restore state when reselecting a previously selected item
+      //      restoreState = true
     }
   }
 

--- a/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
@@ -20,7 +20,9 @@ fun NavigationBar(navigation: Navigation) {
               icon = { Icon(destination.icon, contentDescription = destination.textId) },
               label = { Text(destination.textId) },
               selected = navigation.getCurrentDestination().route == destination.route,
-              onClick = { navigation.navigateTo(destination) })
+              onClick = {
+                      navigation.navigateTo(destination)
+              })
         }
       })
 }

--- a/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
@@ -20,9 +20,7 @@ fun NavigationBar(navigation: Navigation) {
               icon = { Icon(destination.icon, contentDescription = destination.textId) },
               label = { Text(destination.textId) },
               selected = navigation.getCurrentDestination().route == destination.route,
-              onClick = {
-                      navigation.navigateTo(destination)
-              })
+              onClick = { navigation.navigateTo(destination) })
         }
       })
 }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -144,9 +144,7 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
                     DisplayItinerary(
                         itinerary = itinerary,
                         navigation = navigation,
-                        onClick = {
-                          navigation.navigateTo(Route.MAPS, itinerary.id)
-                        })
+                        onClick = { navigation.navigateTo(Route.MAPS, itinerary.id) })
                   }
                 }
             /*

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -270,10 +270,7 @@ fun SearchBarImplementation(
         items(listToShow) { itinerary ->
           ItineraryItem(
               itinerary = itinerary,
-              onItineraryClick = {
-                navigation.navigateTo(navigation.getTopLevelDestinations()[1])
-                navigation.navController.navigate(Route.MAPS + "/${itinerary.id}")
-              })
+              onItineraryClick = { navigation.navigateTo(Route.MAPS, itinerary.id) })
         }
       }
     }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -273,7 +273,10 @@ fun SearchBarImplementation(
         items(listToShow) { itinerary ->
           ItineraryItem(
               itinerary = itinerary,
-              onItineraryClick = { /* TODO: Implement navigation to itinerary details */})
+              onItineraryClick = {
+                navigation.navigateTo(navigation.getTopLevelDestinations()[1])
+                navigation.navController.navigate(Route.MAPS + "/${itinerary.id}")
+              })
         }
       }
     }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -145,7 +145,6 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
                         itinerary = itinerary,
                         navigation = navigation,
                         onClick = {
-                          Log.d("CHANGED_DESTINATION_ID", itinerary.id)
                           navigation.navigateTo(Route.MAPS, itinerary.id)
                         })
                   }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -143,9 +143,7 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
                         navigation = navigation,
                         onClick = {
                           navigation.navigateTo(navigation.getTopLevelDestinations()[1])
-                          navigation.navController.navigate(
-                              Route.MAPS +
-                                  "/${itinerary.location.latitude}/${itinerary.location.longitude}")
+                          navigation.navController.navigate(Route.MAPS + "/${itinerary.id}")
                         })
                   }
                 }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -145,8 +145,8 @@ fun HomeScreen(navigation: Navigation, homeViewModel: HomeViewModel = viewModel(
                         itinerary = itinerary,
                         navigation = navigation,
                         onClick = {
-                          navigation.navigateTo(navigation.getTopLevelDestinations()[1])
-                          navigation.navController.navigate(Route.MAPS + "/${itinerary.id}")
+                          Log.d("CHANGED_DESTINATION_ID", itinerary.id)
+                          navigation.navigateTo(Route.MAPS, itinerary.id)
                         })
                   }
                 }

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -149,7 +149,7 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                           fontFamily = FontFamily(Font(R.font.montserrat_regular)),
                           fontWeight = FontWeight.Bold,
                           fontSize = 30.sp,
-                          modifier = Modifier.padding(start = 130.dp))
+                          modifier = Modifier.padding(start = 130.dp).testTag("SpotTitle"))
                       // Close button
                       IconButton(
                           modifier = Modifier.padding(10.dp).testTag("CloseButton"),

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
@@ -137,7 +138,7 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                     .padding(top = 80.dp, start = 15.dp, end = 15.dp, bottom = 20.dp)
                     .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))
                     .testTag("AddSpotScreen")) {
-              Column(modifier = Modifier.matchParentSize()) {
+              Column(modifier = Modifier.matchParentSize().verticalScroll(rememberScrollState())) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -24,20 +24,20 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.outlined.AddPhotoAlternate
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.material.icons.outlined.Image
 import androidx.compose.material.icons.outlined.Map
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,6 +55,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -68,14 +69,13 @@ import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.repository.Response
 import com.example.triptracker.navigation.compareDistance
 import com.example.triptracker.view.theme.Montserrat
-import com.example.triptracker.view.theme.md_theme_dark_error
-import com.example.triptracker.view.theme.md_theme_dark_gray
 import com.example.triptracker.view.theme.md_theme_light_black
+import com.example.triptracker.view.theme.md_theme_light_error
 import com.example.triptracker.view.theme.md_theme_light_onPrimary
+import com.example.triptracker.view.theme.md_theme_light_secondary
 import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.RecordViewModel
 import com.google.android.gms.maps.model.LatLng
-import kotlinx.coroutines.launch
 
 @Composable
 /**
@@ -132,35 +132,33 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
     true ->
         Box(
             modifier =
-                Modifier.fillMaxSize()
-                    .padding(15.dp)
+                Modifier.fillMaxWidth()
+                    .fillMaxHeight(0.85f)
+                    .padding(top = 80.dp, start = 15.dp, end = 15.dp, bottom = 20.dp)
                     .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))
                     .testTag("AddSpotScreen")) {
               Column(modifier = Modifier.matchParentSize()) {
-
-                // Close button
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                  IconButton(
-                      modifier = Modifier.padding(10.dp).testTag("CloseButton"),
-                      onClick = { alertIsDisplayed = true }) {
-                        Icon(
-                            imageVector = Icons.Outlined.Close,
-                            contentDescription = "Close",
-                            tint = md_theme_light_onPrimary)
-                      }
-                }
-
-                // Title
                 Row(
-                    modifier = Modifier.fillMaxWidth().testTag("SpotTitle"),
-                    horizontalArrangement = Arrangement.Center) {
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically) {
+                      // Title
                       Text(
-                          text = "Add New Spot To Path",
-                          color = md_theme_orange,
+                          text = "Add Spot",
+                          color = Color.White,
                           fontFamily = FontFamily(Font(R.font.montserrat_regular)),
-                          fontWeight = FontWeight.Normal,
+                          fontWeight = FontWeight.Bold,
                           fontSize = 30.sp,
-                      )
+                          modifier = Modifier.padding(start = 130.dp))
+                      // Close button
+                      IconButton(
+                          modifier = Modifier.padding(10.dp).testTag("CloseButton"),
+                          onClick = { alertIsDisplayed = true }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Close,
+                                contentDescription = "Close",
+                                tint = md_theme_light_onPrimary)
+                          }
                     }
 
                 val expanded = remember { mutableStateOf(false) }
@@ -178,7 +176,7 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(top = 30.dp).testTag("SpotLocation"),
                     horizontalArrangement = Arrangement.Center) {
-                      TextField(
+                      OutlinedTextField(
                           enabled = recordViewModel.namePOI.value.isEmpty(),
                           modifier =
                               Modifier.padding(horizontal = 20.dp)
@@ -192,6 +190,9 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                             recordViewModel.getSuggestion(it) { latLng -> pos = latLng }
                             Log.d("Suggestion", pos.toString())
                             expanded.value = true
+                            if (it.isNotEmpty()) {
+                              isError = false
+                            }
                           },
                           label = {
                             Text("Point of Interest name", color = md_theme_light_onPrimary)
@@ -203,19 +204,29 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                                 tint = md_theme_orange)
                           },
                           colors =
-                              TextFieldDefaults.textFieldColors(
-                                  unfocusedLabelColor = md_theme_light_onPrimary,
-                                  focusedLabelColor = md_theme_orange,
+                              OutlinedTextFieldDefaults.colors(
+                                  unfocusedTextColor = md_theme_light_onPrimary,
+                                  unfocusedBorderColor =
+                                      if (recordViewModel.namePOI.value.isNotEmpty())
+                                          md_theme_light_error
+                                      else md_theme_light_onPrimary,
+                                  unfocusedLabelColor =
+                                      if (recordViewModel.namePOI.value.isNotEmpty())
+                                          md_theme_light_error
+                                      else md_theme_light_onPrimary,
                                   cursorColor = md_theme_orange,
-                                  backgroundColor =
-                                      if (!isError) md_theme_dark_gray else md_theme_dark_error,
-                                  focusedIndicatorColor = md_theme_orange,
+                                  focusedBorderColor = md_theme_light_onPrimary,
+                                  focusedLabelColor = md_theme_light_onPrimary,
+                                  disabledBorderColor = md_theme_light_secondary,
                               ),
-                          shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
                           minLines = 1,
                           maxLines = 1,
                           isError = isError,
-                          placeholder = { if (isError) Text(placeHolderError) else Text("") },
+                          placeholder = {
+                            if (isError) Text(placeHolderError, color = md_theme_light_onPrimary)
+                            else Text("", color = md_theme_light_onPrimary)
+                          },
+                          textStyle = TextStyle(color = md_theme_light_onPrimary),
                       )
 
                       DropdownMenu(
@@ -252,7 +263,7 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                 Row(
                     modifier = Modifier.fillMaxWidth().testTag("SpotDescription"),
                     horizontalArrangement = Arrangement.Center) {
-                      TextField(
+                      OutlinedTextField(
                           modifier =
                               Modifier.padding(horizontal = 20.dp, vertical = 20.dp)
                                   .fillMaxWidth()
@@ -273,16 +284,17 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                                 tint = md_theme_orange)
                           },
                           colors =
-                              TextFieldDefaults.textFieldColors(
+                              OutlinedTextFieldDefaults.colors(
+                                  unfocusedTextColor = md_theme_light_onPrimary,
+                                  unfocusedBorderColor = md_theme_light_onPrimary,
                                   unfocusedLabelColor = md_theme_light_onPrimary,
-                                  focusedLabelColor = md_theme_orange,
                                   cursorColor = md_theme_orange,
-                                  backgroundColor = md_theme_dark_gray,
-                                  focusedIndicatorColor = md_theme_orange,
+                                  focusedBorderColor = md_theme_light_onPrimary,
+                                  focusedLabelColor = md_theme_light_onPrimary,
                               ),
-                          shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
                           minLines = 5,
                           maxLines = 5,
+                          textStyle = TextStyle(color = md_theme_light_onPrimary),
                       )
                     }
 
@@ -368,14 +380,15 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
                           modifier = Modifier.padding(horizontal = 20.dp, vertical = 30.dp),
                           colors =
                               ButtonDefaults.filledTonalButtonColors(
-                                  containerColor = md_theme_orange, contentColor = Color.White),
+                                  containerColor = md_theme_light_onPrimary,
+                                  contentColor = Color.White),
                       ) {
                         Text(
                             text = "Save",
                             fontSize = 24.sp,
                             fontFamily = Montserrat,
                             fontWeight = FontWeight.SemiBold,
-                            color = Color.White)
+                            color = md_theme_light_black)
                       }
                     }
               }
@@ -462,7 +475,7 @@ fun InsertPictures(
                   .padding(horizontal = 20.dp, vertical = 5.dp)
                   .drawBehind {
                     drawRoundRect(
-                        color = md_theme_orange,
+                        color = md_theme_light_secondary,
                         style = stroke,
                         cornerRadius = CornerRadius(16.dp.toPx()))
                   }
@@ -482,7 +495,7 @@ fun InsertPictures(
                   horizontalArrangement = Arrangement.Center,
                   verticalAlignment = Alignment.CenterVertically) {
                     Icon(
-                        imageVector = Icons.Outlined.Image,
+                        imageVector = Icons.Outlined.AddPhotoAlternate,
                         contentDescription = "Add Picture",
                         tint = md_theme_orange)
                   }
@@ -493,7 +506,7 @@ fun InsertPictures(
                   horizontalArrangement = Arrangement.Center) {
                     Text(
                         text = "Add new pictures (max. 5)",
-                        color = md_theme_light_onPrimary,
+                        color = md_theme_light_secondary,
                         fontFamily = FontFamily(Font(R.font.montserrat_regular)),
                         fontWeight = FontWeight.Normal,
                         fontSize = 20.sp,
@@ -554,5 +567,5 @@ fun InsertPictures(
 @Composable
 fun AddSpotPreview() {
   AddSpot(RecordViewModel(), LatLng(46.519053, 6.568287))
-  //  AddSpot(RecordViewModel(), LatLng(46.519879, 6.560632))
+  //    AddSpot(RecordViewModel(), LatLng(46.519879, 6.560632))
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -165,15 +165,16 @@ fun Map(
             deviceLocation = it
             position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
           })
-    } else {
-      val location = mapViewModel.getPathById(selectedId)?.location
-      position =
-          if (location != null) {
-            CameraPosition.fromLatLngZoom(LatLng(location.latitude, location.longitude), 17f)
-          } else {
-            CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-          }
     }
+//    else {
+//      val location = mapViewModel.getPathById(selectedId)?.location
+//      position =
+//          if (location != null) {
+//            CameraPosition.fromLatLngZoom(LatLng(location.latitude, location.longitude), 17f)
+//          } else {
+//            CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+//          }
+//    }
   }
   var visibleRegion: VisibleRegion?
 
@@ -207,32 +208,35 @@ fun Map(
 
   val pathList by mapViewModel.pathList.observeAsState()
   LaunchedEffect(pathList) {
-    pathList.let {
-      if (selectedId != "") {
-        val selection = mapViewModel.getPathById(selectedId)
-        if (selection != null) {
-          cameraPositionState.position =
-              CameraPosition.fromLatLngZoom(
-                  LatLng(selection.location.latitude, selection.location.longitude), 17f)
+      if((pathList?.size() ?: 0) > 0) {
+          Log.d("ENTEREDUPDATE", deviceLocation.toString() + " " + pathList?.size().toString())
+          if (selectedId != "") {
+              val selection = mapViewModel.getPathById(pathList!!, selectedId)
+                if (selection != null) {
 
-          mapViewModel.reverseDecode(
-              cameraPositionState.position.target.latitude.toFloat(),
-              cameraPositionState.position.target.longitude.toFloat())
-          visibleRegion = cameraPositionState.projection?.visibleRegion
-          mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
+                  cameraPositionState.position =
+                      CameraPosition.fromLatLngZoom(
+                          LatLng(selection.location.latitude, selection.location.longitude), 17f)
 
-          mapViewModel.selectedPolylineState.value =
-              MapViewModel.SelectedPolyline(selection, selection.route[0])
-          selectedPolyline = mapViewModel.selectedPolylineState.value
-          displayPopUp = true
+                  mapViewModel.reverseDecode(
+                      cameraPositionState.position.target.latitude.toFloat(),
+                      cameraPositionState.position.target.longitude.toFloat())
+                  visibleRegion = cameraPositionState.projection?.visibleRegion
+                  mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
+
+                  mapViewModel.selectedPolylineState.value =
+                      MapViewModel.SelectedPolyline(selection, selection.route[0])
+                  selectedPolyline = mapViewModel.selectedPolylineState.value
+                  displayPopUp = true
         }
-      } else {
-        cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-        visibleRegion = cameraPositionState.projection?.visibleRegion
-        mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
-        displayPopUp = false
+          } else {
+                cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+                visibleRegion = cameraPositionState.projection?.visibleRegion
+                mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
+                displayPopUp = false
+          }
       }
-    }
+
   }
 
   // Displays the map

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.PinDrop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -39,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.rememberNavController
 import coil.compose.AsyncImage
 import com.example.triptracker.model.location.popupState
@@ -80,7 +82,7 @@ import com.google.maps.android.compose.rememberMarkerState
  *   purposes (optional)
  */
 fun MapOverview(
-    mapViewModel: MapViewModel = MapViewModel(),
+    mapViewModel: MapViewModel = viewModel(),
     context: Context,
     navigation: Navigation,
     checkLocationPermission: Boolean = true, // Default value true, can be overridden during tests
@@ -267,14 +269,14 @@ fun Map(
 
           // Display the start marker of the polyline and a thicker path when selected
           if (isSelected) {
-            //            val startMarkerState =
-            //                rememberMarkerState(position = selectedPolyline!!.itinerary.route[0])
-            //            MarkerComposable(state = startMarkerState) {
-            //              Icon(
-            //                  imageVector = Icons.Outlined.ArrowDownward,
-            //                  contentDescription = "Start Location",
-            //                  tint = md_theme_light_black)
-            //            }
+//                        val startMarkerState =
+//                            rememberMarkerState(position = selectedPolyline!!.itinerary.route[0])
+//                        MarkerComposable(state = startMarkerState) {
+//                          Icon(
+//                              imageVector = Icons.Outlined.ArrowDownward,
+//                              contentDescription = "Start Location",
+//                              tint = md_theme_light_black)
+//                        }
 
             selectedPolyline!!.itinerary.pinnedPlaces.forEach { pin ->
               val markerState = rememberMarkerState(position = LatLng(pin.latitude, pin.longitude))

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -316,51 +316,68 @@ fun Map(
         modifier = Modifier.align(Alignment.BottomStart),
         horizontalArrangement = Arrangement.Start) {
           Box(modifier = Modifier.padding(horizontal = 35.dp, vertical = 65.dp)) {
-            if (ui.myLocationButtonEnabled &&
-                properties.isMyLocationEnabled &&
-                !displayPopUp &&
-                !displayPicturesPopUp) {
-              DisplayCenterLocationButton(
-                  coroutineScope = coroutineScope,
-                  deviceLocation = deviceLocation,
-                  cameraPositionState = cameraPositionState) {
-                    getCurrentLocation(
-                        context = context,
-                        onLocationFetched = {
-                          deviceLocation = it
-                          cameraPositionState.position =
-                              CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-                        })
+              if (ui.myLocationButtonEnabled &&
+                  properties.isMyLocationEnabled &&
+                  !displayPopUp &&
+                  !displayPicturesPopUp
+              ) {
+                  DisplayCenterLocationButton(
+                      coroutineScope = coroutineScope,
+                      deviceLocation = deviceLocation,
+                      cameraPositionState = cameraPositionState
+                  ) {
+                      getCurrentLocation(
+                          context = context,
+                          onLocationFetched = {
+                              deviceLocation = it
+                              cameraPositionState.position =
+                                  CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+                          })
                   }
-            }
+              }
+          }
+    }
             if (displayPopUp) {
-              Box(modifier = Modifier.fillMaxHeight(0.3f)) {
+
                 if (mapViewModel.selectedPolylineState.value != null) {
                   // Display the itinerary of the selected polyline
                   // (only when the polyline is selected)
                   when (mapPopupState) {
                     popupState.DISPLAYITINERARY -> {
-                      DisplayItinerary(
-                          itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
-                          navigation = navigation,
-                          onClick = { mapPopupState = popupState.PATHOVERLAY })
+                        Box(modifier = Modifier.fillMaxHeight(0.3f).fillMaxWidth().align(Alignment.BottomCenter)) {
+                            DisplayItinerary(
+                                itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
+                                navigation = navigation,
+                                onClick = { mapPopupState = popupState.PATHOVERLAY })
+                        }
                     }
                     popupState.DISPLAYPIN -> {
                       // called detailed view Theo
                     }
                     popupState.PATHOVERLAY -> {
-                      PathOverlaySheet(
-                          itinerary = mapViewModel.selectedPolylineState.value!!.itinerary)
+                        Box(modifier = Modifier.fillMaxWidth().fillMaxHeight(0.3f).align(Alignment.BottomCenter)) {
+                            PathOverlaySheet(
+                                itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
+                                onClick = {
+                                    mapPopupState = popupState.DISPLAYITINERARY
+                                    displayPopUp = false
+                                    displayPicturesPopUp = true
+                                    mapViewModel.selectedPin.value = it
+                                }
+                            )
+                        }
                     }
                   }
                 }
-              }
+
             }
 
             if (displayPicturesPopUp) {
               Box(
                   modifier =
                       Modifier.fillMaxWidth()
+                          .fillMaxHeight(0.4f)
+                          .align(Alignment.BottomCenter)
                           .padding(15.dp)
                           .height(300.dp)
                           .background(
@@ -398,8 +415,9 @@ fun Map(
                         modifier =
                             Modifier.fillMaxSize()
                                 .horizontalScroll(scrollState)
+                                .align(Alignment.BottomStart)
                                 .padding(vertical = 20.dp, horizontal = 20.dp),
-                        horizontalArrangement = Arrangement.End,
+                        horizontalArrangement = Arrangement.Center,
                         verticalAlignment = Alignment.Bottom) {
                           selectedPin?.image_url?.forEach { url ->
                             AsyncImage(
@@ -410,8 +428,8 @@ fun Map(
                         }
                   }
             }
-          }
-        }
+
+
   }
 }
 

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -203,29 +203,30 @@ fun Map(
   // updated
   LaunchedEffect(pathList) {
     Log.d("ISELECTEDOUT", currentSelectedId)
-    if ((pathList?.size() ?: 0) > 0) {
-      Log.d("ISELECTED", currentSelectedId)
-      if (currentSelectedId != "") {
-        Log.d("ISELECTEDIN", currentSelectedId)
-        // fetch the selected path
-        val selection = mapViewModel.getPathById(pathList!!, currentSelectedId)
-        if (selection != null) {
+    //    if ((pathList?.size() ?: 0) > 0) {
+    Log.d("ISELECTED", currentSelectedId)
+    if (currentSelectedId != "") {
+      Log.d("ISELECTEDIN", currentSelectedId)
+      // fetch the selected path
+      val selection = mapViewModel.getPathById(pathList!!, currentSelectedId)
+      Log.d("selection", selection.toString())
+      if (selection != null) {
 
-          // center the camera on the selected path
-          cameraPositionState.position =
-              CameraPosition.fromLatLngZoom(
-                  LatLng(selection.location.latitude, selection.location.longitude), 17f)
+        // center the camera on the selected path
+        cameraPositionState.position =
+            CameraPosition.fromLatLngZoom(
+                LatLng(selection.location.latitude, selection.location.longitude), 17f)
 
-          // set the selected polyline
-          mapViewModel.selectedPolylineState.value =
-              MapViewModel.SelectedPolyline(selection, selection.route[0])
-          selectedPolyline = mapViewModel.selectedPolylineState.value
+        // set the selected polyline
+        mapViewModel.selectedPolylineState.value =
+            MapViewModel.SelectedPolyline(selection, selection.route[0])
+        selectedPolyline = mapViewModel.selectedPolylineState.value
 
-          // display the path popup
-          displayPopUp = true
-        }
+        // display the path popup
+        displayPopUp = true
       }
     }
+    //    }
   }
 
   // Displays the map

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -2,7 +2,6 @@ package com.example.triptracker.view.map
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -202,14 +201,10 @@ fun Map(
   // Get the path list from the view model and trigger the launch effect when the path list is
   // updated
   LaunchedEffect(pathList) {
-    Log.d("ISELECTEDOUT", currentSelectedId)
     //    if ((pathList?.size() ?: 0) > 0) {
-    Log.d("ISELECTED", currentSelectedId)
     if (currentSelectedId != "") {
-      Log.d("ISELECTEDIN", currentSelectedId)
       // fetch the selected path
       val selection = mapViewModel.getPathById(pathList!!, currentSelectedId)
-      Log.d("selection", selection.toString())
       if (selection != null) {
 
         // center the camera on the selected path

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.PinDrop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -269,14 +268,15 @@ fun Map(
 
           // Display the start marker of the polyline and a thicker path when selected
           if (isSelected) {
-//                        val startMarkerState =
-//                            rememberMarkerState(position = selectedPolyline!!.itinerary.route[0])
-//                        MarkerComposable(state = startMarkerState) {
-//                          Icon(
-//                              imageVector = Icons.Outlined.ArrowDownward,
-//                              contentDescription = "Start Location",
-//                              tint = md_theme_light_black)
-//                        }
+            //                        val startMarkerState =
+            //                            rememberMarkerState(position =
+            // selectedPolyline!!.itinerary.route[0])
+            //                        MarkerComposable(state = startMarkerState) {
+            //                          Icon(
+            //                              imageVector = Icons.Outlined.ArrowDownward,
+            //                              contentDescription = "Start Location",
+            //                              tint = md_theme_light_black)
+            //                        }
 
             selectedPolyline!!.itinerary.pinnedPlaces.forEach { pin ->
               val markerState = rememberMarkerState(position = LatLng(pin.latitude, pin.longitude))
@@ -316,120 +316,117 @@ fun Map(
         modifier = Modifier.align(Alignment.BottomStart),
         horizontalArrangement = Arrangement.Start) {
           Box(modifier = Modifier.padding(horizontal = 35.dp, vertical = 65.dp)) {
-              if (ui.myLocationButtonEnabled &&
-                  properties.isMyLocationEnabled &&
-                  !displayPopUp &&
-                  !displayPicturesPopUp
-              ) {
-                  DisplayCenterLocationButton(
-                      coroutineScope = coroutineScope,
-                      deviceLocation = deviceLocation,
-                      cameraPositionState = cameraPositionState
-                  ) {
-                      getCurrentLocation(
-                          context = context,
-                          onLocationFetched = {
-                              deviceLocation = it
-                              cameraPositionState.position =
-                                  CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-                          })
+            if (ui.myLocationButtonEnabled &&
+                properties.isMyLocationEnabled &&
+                !displayPopUp &&
+                !displayPicturesPopUp) {
+              DisplayCenterLocationButton(
+                  coroutineScope = coroutineScope,
+                  deviceLocation = deviceLocation,
+                  cameraPositionState = cameraPositionState) {
+                    getCurrentLocation(
+                        context = context,
+                        onLocationFetched = {
+                          deviceLocation = it
+                          cameraPositionState.position =
+                              CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+                        })
                   }
-              }
+            }
           }
-    }
-            if (displayPopUp) {
+        }
+    if (displayPopUp) {
 
-                if (mapViewModel.selectedPolylineState.value != null) {
-                  // Display the itinerary of the selected polyline
-                  // (only when the polyline is selected)
-                  when (mapPopupState) {
-                    popupState.DISPLAYITINERARY -> {
-                        Box(modifier = Modifier.fillMaxHeight(0.3f).fillMaxWidth().align(Alignment.BottomCenter)) {
-                            DisplayItinerary(
-                                itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
-                                navigation = navigation,
-                                onClick = { mapPopupState = popupState.PATHOVERLAY })
-                        }
-                    }
-                    popupState.DISPLAYPIN -> {
-                      // called detailed view Theo
-                    }
-                    popupState.PATHOVERLAY -> {
-                        Box(modifier = Modifier.fillMaxWidth().fillMaxHeight(0.3f).align(Alignment.BottomCenter)) {
-                            PathOverlaySheet(
-                                itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
-                                onClick = {
-                                    mapPopupState = popupState.DISPLAYITINERARY
-                                    displayPopUp = false
-                                    displayPicturesPopUp = true
-                                    mapViewModel.selectedPin.value = it
-                                }
-                            )
-                        }
-                    }
-                  }
+      if (mapViewModel.selectedPolylineState.value != null) {
+        // Display the itinerary of the selected polyline
+        // (only when the polyline is selected)
+        when (mapPopupState) {
+          popupState.DISPLAYITINERARY -> {
+            Box(
+                modifier =
+                    Modifier.fillMaxHeight(0.3f).fillMaxWidth().align(Alignment.BottomCenter)) {
+                  DisplayItinerary(
+                      itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
+                      navigation = navigation,
+                      onClick = { mapPopupState = popupState.PATHOVERLAY })
+                }
+          }
+          popupState.DISPLAYPIN -> {
+            // called detailed view Theo
+          }
+          popupState.PATHOVERLAY -> {
+            Box(
+                modifier =
+                    Modifier.fillMaxWidth().fillMaxHeight(0.3f).align(Alignment.BottomCenter)) {
+                  PathOverlaySheet(
+                      itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
+                      onClick = {
+                        mapPopupState = popupState.DISPLAYITINERARY
+                        displayPopUp = false
+                        displayPicturesPopUp = true
+                        mapViewModel.selectedPin.value = it
+                      })
+                }
+          }
+        }
+      }
+    }
+
+    if (displayPicturesPopUp) {
+      Box(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .fillMaxHeight(0.4f)
+                  .align(Alignment.BottomCenter)
+                  .padding(15.dp)
+                  .height(300.dp)
+                  .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))) {
+            // Display the pictures of the selected pin
+            // (only when the pin is selected)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically) {
+                  Column(
+                      modifier = Modifier.fillMaxWidth(),
+                      verticalArrangement = Arrangement.Center,
+                      horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            text = mapViewModel.selectedPin.value?.name ?: "",
+                            modifier = Modifier.padding(vertical = 10.dp),
+                            fontSize = 15.sp,
+                            fontFamily = Montserrat,
+                            fontWeight = FontWeight.SemiBold,
+                            color = md_theme_orange)
+                        Text(
+                            text = mapViewModel.selectedPin.value?.description ?: "",
+                            fontSize = 12.sp,
+                            fontFamily = Montserrat,
+                            fontWeight = FontWeight.SemiBold,
+                            color = md_theme_light_onPrimary)
+                      }
                 }
 
-            }
+            val selectedPin = mapViewModel.selectedPin.value
+            val scrollState = rememberScrollState()
 
-            if (displayPicturesPopUp) {
-              Box(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .fillMaxHeight(0.4f)
-                          .align(Alignment.BottomCenter)
-                          .padding(15.dp)
-                          .height(300.dp)
-                          .background(
-                              color = md_theme_light_black, shape = RoundedCornerShape(35.dp))) {
-                    // Display the pictures of the selected pin
-                    // (only when the pin is selected)
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically) {
-                          Column(
-                              modifier = Modifier.fillMaxWidth(),
-                              verticalArrangement = Arrangement.Center,
-                              horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(
-                                    text = mapViewModel.selectedPin.value?.name ?: "",
-                                    modifier = Modifier.padding(vertical = 10.dp),
-                                    fontSize = 15.sp,
-                                    fontFamily = Montserrat,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = md_theme_orange)
-                                Text(
-                                    text = mapViewModel.selectedPin.value?.description ?: "",
-                                    fontSize = 12.sp,
-                                    fontFamily = Montserrat,
-                                    fontWeight = FontWeight.SemiBold,
-                                    color = md_theme_light_onPrimary)
-                              }
-                        }
-
-                    val selectedPin = mapViewModel.selectedPin.value
-                    val scrollState = rememberScrollState()
-
-                    Row(
-                        modifier =
-                            Modifier.fillMaxSize()
-                                .horizontalScroll(scrollState)
-                                .align(Alignment.BottomStart)
-                                .padding(vertical = 20.dp, horizontal = 20.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.Bottom) {
-                          selectedPin?.image_url?.forEach { url ->
-                            AsyncImage(
-                                model = url,
-                                contentDescription = "Image",
-                                modifier = Modifier.height(200.dp).padding(horizontal = 2.dp))
-                          }
-                        }
+            Row(
+                modifier =
+                    Modifier.fillMaxSize()
+                        .horizontalScroll(scrollState)
+                        .align(Alignment.BottomStart)
+                        .padding(vertical = 20.dp, horizontal = 20.dp),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.Bottom) {
+                  selectedPin?.image_url?.forEach { url ->
+                    AsyncImage(
+                        model = url,
+                        contentDescription = "Image",
+                        modifier = Modifier.height(200.dp).padding(horizontal = 2.dp))
                   }
-            }
-
-
+                }
+          }
+    }
   }
 }
 

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -166,20 +166,11 @@ fun Map(
             position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
           })
     }
-//    else {
-//      val location = mapViewModel.getPathById(selectedId)?.location
-//      position =
-//          if (location != null) {
-//            CameraPosition.fromLatLngZoom(LatLng(location.latitude, location.longitude), 17f)
-//          } else {
-//            CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-//          }
-//    }
   }
   var visibleRegion: VisibleRegion?
 
-  var displayPopUp by remember { mutableStateOf(mapViewModel.displayPopUp.value) }
-  var displayPicturesPopUp by remember { mutableStateOf(mapViewModel.displayPicturesPopUp.value) }
+  var displayPopUp by remember { mutableStateOf(false) }
+  var displayPicturesPopUp by remember { mutableStateOf(false) }
 
   var selectedPolyline by remember { mapViewModel.selectedPolylineState }
 
@@ -208,35 +199,34 @@ fun Map(
 
   val pathList by mapViewModel.pathList.observeAsState()
   LaunchedEffect(pathList) {
-      if((pathList?.size() ?: 0) > 0) {
-          Log.d("ENTEREDUPDATE", deviceLocation.toString() + " " + pathList?.size().toString())
-          if (selectedId != "") {
-              val selection = mapViewModel.getPathById(pathList!!, selectedId)
-                if (selection != null) {
+    if ((pathList?.size() ?: 0) > 0) {
+      Log.d("ENTEREDUPDATE", deviceLocation.toString() + " " + pathList?.size().toString())
+      if (selectedId != "") {
+        val selection = mapViewModel.getPathById(pathList!!, selectedId)
+        if (selection != null) {
 
-                  cameraPositionState.position =
-                      CameraPosition.fromLatLngZoom(
-                          LatLng(selection.location.latitude, selection.location.longitude), 17f)
+          cameraPositionState.position =
+              CameraPosition.fromLatLngZoom(
+                  LatLng(selection.location.latitude, selection.location.longitude), 17f)
 
-                  mapViewModel.reverseDecode(
-                      cameraPositionState.position.target.latitude.toFloat(),
-                      cameraPositionState.position.target.longitude.toFloat())
-                  visibleRegion = cameraPositionState.projection?.visibleRegion
-                  mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
+          mapViewModel.reverseDecode(
+              cameraPositionState.position.target.latitude.toFloat(),
+              cameraPositionState.position.target.longitude.toFloat())
+          visibleRegion = cameraPositionState.projection?.visibleRegion
+          mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
 
-                  mapViewModel.selectedPolylineState.value =
-                      MapViewModel.SelectedPolyline(selection, selection.route[0])
-                  selectedPolyline = mapViewModel.selectedPolylineState.value
-                  displayPopUp = true
+          mapViewModel.selectedPolylineState.value =
+              MapViewModel.SelectedPolyline(selection, selection.route[0])
+          selectedPolyline = mapViewModel.selectedPolylineState.value
+          displayPopUp = true
         }
-          } else {
-                cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
-                visibleRegion = cameraPositionState.projection?.visibleRegion
-                mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
-                displayPopUp = false
-          }
+      } else {
+        cameraPositionState.position = CameraPosition.fromLatLngZoom(deviceLocation, 17f)
+        visibleRegion = cameraPositionState.projection?.visibleRegion
+        mapViewModel.getFilteredPaths(visibleRegion?.latLngBounds)
+        displayPopUp = false
       }
-
+    }
   }
 
   // Displays the map

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -2,6 +2,7 @@ package com.example.triptracker.view.map
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -201,27 +202,28 @@ fun Map(
   // Get the path list from the view model and trigger the launch effect when the path list is
   // updated
   LaunchedEffect(pathList) {
-    //    if ((pathList?.size() ?: 0) > 0) {
     if (currentSelectedId != "") {
       // fetch the selected path
-      val selection = mapViewModel.getPathById(pathList!!, currentSelectedId)
-      if (selection != null) {
+      Log.d("MapOverviewPRINT", pathList?.size().toString())
+      if (pathList != null) {
+        val selection = mapViewModel.getPathById(pathList!!, currentSelectedId)
+        if (selection != null) {
 
-        // center the camera on the selected path
-        cameraPositionState.position =
-            CameraPosition.fromLatLngZoom(
-                LatLng(selection.location.latitude, selection.location.longitude), 17f)
+          // center the camera on the selected path
+          cameraPositionState.position =
+              CameraPosition.fromLatLngZoom(
+                  LatLng(selection.location.latitude, selection.location.longitude), 17f)
 
-        // set the selected polyline
-        mapViewModel.selectedPolylineState.value =
-            MapViewModel.SelectedPolyline(selection, selection.route[0])
-        selectedPolyline = mapViewModel.selectedPolylineState.value
+          // set the selected polyline
+          mapViewModel.selectedPolylineState.value =
+              MapViewModel.SelectedPolyline(selection, selection.route[0])
+          selectedPolyline = mapViewModel.selectedPolylineState.value
 
-        // display the path popup
-        displayPopUp = true
+          // display the path popup
+          displayPopUp = true
+        }
       }
     }
-    //    }
   }
 
   // Displays the map

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -68,12 +69,15 @@ fun PathOverlaySheet(
       Box(
           modifier =
               Modifier.fillMaxWidth()
+                  .fillMaxHeight()
                   .background(
                       color = md_theme_light_black,
-                      shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp)
-                  )) {
+                      shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp))) {
             Column(modifier = Modifier.fillMaxWidth().testTag("PathOverlaySheet").padding(25.dp)) {
-              Text(text = profile.username + "'s Path", color = md_theme_light_onPrimary, modifier = Modifier.padding(end = 10.dp))
+              Text(
+                  text = profile.username + "'s Path",
+                  color = md_theme_light_onPrimary,
+                  modifier = Modifier.padding(end = 10.dp))
               Spacer(modifier = Modifier.height(16.dp))
 
               // This lazy column will display all the pins in the path
@@ -97,27 +101,29 @@ fun PathOverlaySheet(
  */
 @Composable
 fun PathItem(pinnedPlace: Pin, onClick: (Pin) -> Unit) {
-  Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { onClick(pinnedPlace) }) {
-    Icon(
-        painter =
-            painterResource(
-                id = R.drawable.ic_gps_fixed), // Replace with your actual pin icon resource
-        contentDescription = "Location pin",
-        tint = Color.White)
-    Column(modifier = Modifier.weight(1f).testTag("PathItem").padding(start = 16.dp)) {
-      Text(text = pinnedPlace.name, color = Color.White)
-      // Fetch address
-      AddressText(
-          mpv = MapPopupViewModel(),
-          latitude = pinnedPlace.latitude.toFloat(),
-          longitude = pinnedPlace.longitude.toFloat())
-    }
-    Icon(
-        painterResource(id = R.drawable.rightarrow),
-        modifier = Modifier.size(16.dp),
-        contentDescription = "More info",
-        tint = Color.White)
-  }
+  Row(
+      verticalAlignment = Alignment.CenterVertically,
+      modifier = Modifier.clickable { onClick(pinnedPlace) }) {
+        Icon(
+            painter =
+                painterResource(
+                    id = R.drawable.ic_gps_fixed), // Replace with your actual pin icon resource
+            contentDescription = "Location pin",
+            tint = Color.White)
+        Column(modifier = Modifier.weight(1f).testTag("PathItem").padding(start = 16.dp)) {
+          Text(text = pinnedPlace.name, color = Color.White)
+          // Fetch address
+          AddressText(
+              mpv = MapPopupViewModel(),
+              latitude = pinnedPlace.latitude.toFloat(),
+              longitude = pinnedPlace.longitude.toFloat())
+        }
+        Icon(
+            painterResource(id = R.drawable.rightarrow),
+            modifier = Modifier.size(16.dp),
+            contentDescription = "More info",
+            tint = Color.White)
+      }
   Spacer(modifier = Modifier.height(16.dp))
 }
 

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -2,6 +2,7 @@ package com.example.triptracker.view.map
 
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -34,6 +35,7 @@ import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.theme.md_theme_light_black
+import com.example.triptracker.view.theme.md_theme_light_onPrimary
 import com.example.triptracker.viewmodel.MapPopupViewModel
 import com.example.triptracker.viewmodel.UserProfileViewModel
 
@@ -45,7 +47,8 @@ import com.example.triptracker.viewmodel.UserProfileViewModel
 @Composable
 fun PathOverlaySheet(
     itinerary: Itinerary,
-    userProfileViewModel: UserProfileViewModel = UserProfileViewModel()
+    userProfileViewModel: UserProfileViewModel = UserProfileViewModel(),
+    onClick: (Pin) -> Unit
 ) {
   var readyToDisplay by remember { mutableStateOf(false) }
   var profile by remember { mutableStateOf(UserProfile("")) }
@@ -65,19 +68,19 @@ fun PathOverlaySheet(
       Box(
           modifier =
               Modifier.fillMaxWidth()
-                  .padding(vertical = 10.dp)
                   .background(
                       color = md_theme_light_black,
-                      shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp))) {
+                      shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp)
+                  )) {
             Column(modifier = Modifier.fillMaxWidth().testTag("PathOverlaySheet").padding(25.dp)) {
-              Text(text = profile.username + "'s Path", color = Color.White)
+              Text(text = profile.username + "'s Path", color = md_theme_light_onPrimary, modifier = Modifier.padding(end = 10.dp))
               Spacer(modifier = Modifier.height(16.dp))
 
               // This lazy column will display all the pins in the path
               // Each pin will be displayed using the PathItem composable
               LazyColumn {
                 items(itinerary.pinnedPlaces) { pin ->
-                  PathItem(pin)
+                  PathItem(pin, onClick)
                   Divider(thickness = 1.dp)
                 }
               }
@@ -92,27 +95,9 @@ fun PathOverlaySheet(
  *
  * @param pinnedPlace specific Pin to be displayed
  */
-
-/**
- * PathItem is a composable function that displays a single pin in the path
- *
- * @param pinnedPlace specific Pin to be displayed
- */
-
-/**
- * PathItem is a composable function that displays a single pin in the path
- *
- * @param pinnedPlace specific Pin to be displayed
- */
-
-/**
- * PathItem is a composable function that displays a single pin in the path
- *
- * @param pinnedPlace specific Pin to be displayed
- */
 @Composable
-fun PathItem(pinnedPlace: Pin) {
-  Row(verticalAlignment = Alignment.CenterVertically) {
+fun PathItem(pinnedPlace: Pin, onClick: (Pin) -> Unit) {
+  Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.clickable { onClick(pinnedPlace) }) {
     Icon(
         painter =
             painterResource(

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -68,6 +68,7 @@ import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
 import com.example.triptracker.view.theme.md_theme_light_error
+import com.example.triptracker.view.theme.md_theme_light_onPrimary
 import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.RecordViewModel
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -227,7 +228,7 @@ fun Map(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-          Box(modifier = Modifier.size(100.dp).background(Color.White))
+          Box(modifier = Modifier.size(100.dp).background(md_theme_light_onPrimary))
         }
       } else {
         GoogleMap(
@@ -276,45 +277,43 @@ fun Map(
     if (!viewModel.isInDescription()) {
       StartWindow(viewModel = viewModel, context)
 
-      if (!viewModel.addSpotClicked.value) {
-        // Button to center on device location
-        Row(
-            modifier = Modifier.align(Alignment.BottomCenter),
-            horizontalArrangement = Arrangement.Center) {
-              if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
-                Box(modifier = Modifier.padding(horizontal = 0.dp, vertical = 60.dp)) {
-                  DisplayCenterLocationButton(
-                      coroutineScope = coroutineScope,
-                      deviceLocation = deviceLocation,
-                      cameraPositionState = cameraPositionState) { /* DO NOTHING*/}
-                }
-              }
-
-              // Button to start/stop recording
-              FilledTonalButton(
-                  onClick = {
-                    if (viewModel.isRecording()) {
-                      viewModel.stopRecording()
-                      viewModel.startDescription()
-                    } else {
-                      viewModel.startRecording()
-                    }
-                  },
-                  modifier = Modifier.padding(50.dp).fillMaxWidth(0.6f).fillMaxHeight(0.1f),
-                  colors =
-                      ButtonDefaults.filledTonalButtonColors(
-                          containerColor = md_theme_orange, contentColor = Color.White),
-              ) {
-                Text(
-                    text = if (viewModel.isRecording()) "Stop" else "Start",
-                    fontSize = 24.sp,
-                    fontFamily = Montserrat,
-                    fontWeight = FontWeight.SemiBold,
-                    color = Color.White)
+      // Button to center on device location
+      Row(
+          modifier = Modifier.align(Alignment.BottomCenter),
+          horizontalArrangement = Arrangement.Center) {
+            if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
+              Box(modifier = Modifier.padding(horizontal = 0.dp, vertical = 60.dp)) {
+                DisplayCenterLocationButton(
+                    coroutineScope = coroutineScope,
+                    deviceLocation = deviceLocation,
+                    cameraPositionState = cameraPositionState) { /* DO NOTHING*/}
               }
             }
-        Spacer(modifier = Modifier.width(50.dp))
-      }
+
+            // Button to start/stop recording
+            FilledTonalButton(
+                onClick = {
+                  if (viewModel.isRecording()) {
+                    viewModel.stopRecording()
+                    viewModel.startDescription()
+                  } else {
+                    viewModel.startRecording()
+                  }
+                },
+                modifier = Modifier.padding(50.dp).fillMaxWidth(0.6f).fillMaxHeight(0.1f),
+                colors =
+                    ButtonDefaults.filledTonalButtonColors(
+                        containerColor = md_theme_orange, contentColor = md_theme_light_onPrimary),
+            ) {
+              Text(
+                  text = if (viewModel.isRecording()) "Stop" else "Start",
+                  fontSize = 24.sp,
+                  fontFamily = Montserrat,
+                  fontWeight = FontWeight.SemiBold,
+                  color = md_theme_light_onPrimary)
+            }
+          }
+      Spacer(modifier = Modifier.width(50.dp))
     }
 
     var isTitleEmpty by remember { mutableStateOf(false) }
@@ -341,7 +340,7 @@ fun Map(
                           fontSize = 36.sp,
                           fontFamily = Montserrat,
                           fontWeight = FontWeight.Bold,
-                          color = Color.White,
+                          color = md_theme_light_onPrimary,
                           modifier = Modifier.padding(top = 50.dp, start = 30.dp, end = 30.dp),
                       )
                       // add a text field for the title
@@ -367,7 +366,7 @@ fun Map(
                                 fontSize = 14.sp,
                                 fontFamily = Montserrat,
                                 fontWeight = FontWeight.Normal,
-                            )
+                                color = md_theme_grey)
                           },
                           modifier =
                               Modifier.fillMaxWidth(1f)
@@ -375,21 +374,22 @@ fun Map(
                                   .testTag("TitleTextField"),
                           textStyle =
                               TextStyle(
-                                  color = Color.White,
+                                  color = md_theme_light_onPrimary,
                                   fontSize = 16.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.Normal),
                           colors =
                               OutlinedTextFieldDefaults.colors(
-                                  unfocusedTextColor = Color.White,
+                                  unfocusedTextColor = md_theme_light_onPrimary,
                                   unfocusedBorderColor =
                                       if (isTitleEmpty) md_theme_light_error else md_theme_grey,
                                   unfocusedLabelColor =
                                       if (isTitleEmpty) md_theme_light_error else md_theme_grey,
-                                  cursorColor = Color.White,
-                                  focusedBorderColor = Color.White,
-                                  focusedLabelColor = Color.White,
-                              ))
+                                  cursorColor = md_theme_light_onPrimary,
+                                  focusedBorderColor = md_theme_light_onPrimary,
+                                  focusedLabelColor = md_theme_light_onPrimary,
+                              ),
+                      )
 
                       // add a text field for the description
                       Text(
@@ -414,6 +414,7 @@ fun Map(
                                 fontSize = 14.sp,
                                 fontFamily = Montserrat,
                                 fontWeight = FontWeight.Normal,
+                                color = md_theme_grey,
                             )
                           },
                           modifier =
@@ -424,23 +425,23 @@ fun Map(
                                   .testTag("DescriptionTextField"),
                           textStyle =
                               TextStyle(
-                                  color = Color.White,
+                                  color = md_theme_light_onPrimary,
                                   fontSize = 16.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.Normal,
                                   lineHeight = 10.sp),
                           colors =
                               OutlinedTextFieldDefaults.colors(
-                                  unfocusedTextColor = Color.White,
+                                  unfocusedTextColor = md_theme_light_onPrimary,
                                   unfocusedBorderColor =
                                       if (isDescriptionEmpty) md_theme_light_error
                                       else md_theme_grey,
                                   unfocusedLabelColor =
                                       if (isDescriptionEmpty) md_theme_light_error
                                       else md_theme_grey,
-                                  cursorColor = Color.White,
-                                  focusedBorderColor = Color.White,
-                                  focusedLabelColor = Color.White,
+                                  cursorColor = md_theme_light_onPrimary,
+                                  focusedBorderColor = md_theme_light_onPrimary,
+                                  focusedLabelColor = md_theme_light_onPrimary,
                               ))
 
                       Row(
@@ -498,14 +499,14 @@ fun Map(
                                 colors =
                                     ButtonDefaults.filledTonalButtonColors(
                                         containerColor = md_theme_orange,
-                                        contentColor = Color.White),
+                                        contentColor = md_theme_light_onPrimary),
                             ) {
                               Text(
                                   text = "Save",
                                   fontSize = 24.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.SemiBold,
-                                  color = Color.White)
+                                  color = md_theme_light_onPrimary)
                             }
                             Spacer(modifier = Modifier.width(20.dp))
                           }
@@ -572,7 +573,7 @@ fun StartWindow(viewModel: RecordViewModel, context: Context) {
                                   fontSize = 22.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.SemiBold,
-                                  color = Color.White)
+                                  color = md_theme_light_onPrimary)
                               Text(
                                   text = displayTime(timer.longValue),
                                   modifier =
@@ -580,7 +581,7 @@ fun StartWindow(viewModel: RecordViewModel, context: Context) {
                                   fontSize = 22.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.SemiBold,
-                                  color = Color.White)
+                                  color = md_theme_light_onPrimary)
                             }
                       }
                 }
@@ -617,7 +618,7 @@ fun StartWindow(viewModel: RecordViewModel, context: Context) {
                                           .fillMaxHeight(0.6f),
                                   colors =
                                       ButtonDefaults.filledTonalButtonColors(
-                                          containerColor = Color.White,
+                                          containerColor = md_theme_light_onPrimary,
                                           contentColor = md_theme_light_dark),
                               ) {
                                 Text(
@@ -643,7 +644,8 @@ fun StartWindow(viewModel: RecordViewModel, context: Context) {
                                         modifier =
                                             Modifier.align(Alignment.CenterVertically)
                                                 .size(50.dp)
-                                                .background(Color.White, shape = CircleShape),
+                                                .background(
+                                                    md_theme_light_onPrimary, shape = CircleShape),
                                     ) {
                                       Icon(
                                           imageVector = Icons.Outlined.Add,

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -4,10 +4,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import com.example.triptracker.model.geocoder.NominatimApi
 import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.model.itinerary.ItineraryList
+import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.repository.ItineraryRepository
 import com.google.android.gms.maps.model.LatLng
@@ -32,6 +34,11 @@ class MapViewModel(
     val filteredPathList: MutableLiveData<Map<Itinerary, List<LatLng>>> =
         MutableLiveData<Map<Itinerary, List<LatLng>>>()
 ) : ViewModel() {
+
+  val DUMMY_SELECTED_POLYLINE =
+      SelectedPolyline(
+          Itinerary("", "", "", Location(0.0, 0.0, ""), 0, "", "", emptyList(), "", emptyList()),
+          LatLng(0.0, 0.0))
 
   // state for the city name displayed at the top of the screen
   val cityNameState = mutableStateOf("")
@@ -96,5 +103,30 @@ class MapViewModel(
               ?.map { it to it.route }
               ?.toMap() ?: emptyMap())
     }
+  }
+
+  fun getPathById(id: String, _pathList: MutableLiveData<ItineraryList> = pathList): Itinerary? {
+    return _pathList.value?.getAllItineraries()?.find { it.id == id }
+  }
+
+  fun getPathByLatLng(
+      latLng: LatLng,
+      _pathList: MutableLiveData<ItineraryList> = pathList
+  ): SelectedPolyline {
+    //        filteredPathList.postValue(
+    //            _pathList.value?.getAllItineraries()?.map { itinerary ->
+    //                itinerary to itinerary.route
+    //            }?.toMap() ?: emptyMap()
+    //        )
+    //        filteredPathList.value?.filter { (itinerary, route) ->
+    //            val location = LatLng(itinerary.location.latitude, itinerary.location.longitude)
+    //            Log.d("FOUNDRESULT", location.toString() + " " + latLng.toString())
+    //            location == latLng
+    //        }?.forEach { (itinerary, route) ->
+    //            Log.d("FOUNDRESULT", "getPathByLatLng: $itinerary")
+    //            selectedPolylineState.value = SelectedPolyline(itinerary, latLng)
+    //            return SelectedPolyline(itinerary, latLng)
+    //        }
+    return DUMMY_SELECTED_POLYLINE
   }
 }

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.triptracker.viewmodel
 
+import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
@@ -105,28 +106,12 @@ class MapViewModel(
     }
   }
 
-  fun getPathById(id: String, _pathList: MutableLiveData<ItineraryList> = pathList): Itinerary? {
-    return _pathList.value?.getAllItineraries()?.find { it.id == id }
-  }
-
-  fun getPathByLatLng(
-      latLng: LatLng,
-      _pathList: MutableLiveData<ItineraryList> = pathList
-  ): SelectedPolyline {
-    //        filteredPathList.postValue(
-    //            _pathList.value?.getAllItineraries()?.map { itinerary ->
-    //                itinerary to itinerary.route
-    //            }?.toMap() ?: emptyMap()
-    //        )
-    //        filteredPathList.value?.filter { (itinerary, route) ->
-    //            val location = LatLng(itinerary.location.latitude, itinerary.location.longitude)
-    //            Log.d("FOUNDRESULT", location.toString() + " " + latLng.toString())
-    //            location == latLng
-    //        }?.forEach { (itinerary, route) ->
-    //            Log.d("FOUNDRESULT", "getPathByLatLng: $itinerary")
-    //            selectedPolylineState.value = SelectedPolyline(itinerary, latLng)
-    //            return SelectedPolyline(itinerary, latLng)
-    //        }
-    return DUMMY_SELECTED_POLYLINE
+    /**
+     * Get the path by id
+     * @param id : the id of the path
+     * @return the path with the id or null if not found
+     */
+  fun getPathById(pathL : ItineraryList, id: String): Itinerary? {
+      return pathL.getAllItineraries().find { it.id == id }
   }
 }

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
  */
 class MapViewModel(
     val geocoder: NominatimApi = NominatimApi(),
-    private val pathList: MutableLiveData<ItineraryList> = MutableLiveData<ItineraryList>(),
+    val pathList: MutableLiveData<ItineraryList> = MutableLiveData<ItineraryList>(),
     private val repository: ItineraryRepository = ItineraryRepository(),
     val filteredPathList: MutableLiveData<Map<Itinerary, List<LatLng>>> =
         MutableLiveData<Map<Itinerary, List<LatLng>>>()

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -1,6 +1,5 @@
 package com.example.triptracker.viewmodel
 
-import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
@@ -52,10 +51,6 @@ class MapViewModel(
 
   var selectedPin = mutableStateOf<Pin?>(null)
 
-  var displayPopUp = mutableStateOf(false)
-
-  var displayPicturesPopUp = mutableStateOf(false)
-
   init {
     viewModelScope.launch { getAllItineraries() }
   }
@@ -106,12 +101,13 @@ class MapViewModel(
     }
   }
 
-    /**
-     * Get the path by id
-     * @param id : the id of the path
-     * @return the path with the id or null if not found
-     */
-  fun getPathById(pathL : ItineraryList, id: String): Itinerary? {
-      return pathL.getAllItineraries().find { it.id == id }
+  /**
+   * Get the path by id
+   *
+   * @param id : the id of the path
+   * @return the path with the id or null if not found
+   */
+  fun getPathById(pathL: ItineraryList, id: String): Itinerary? {
+    return pathL.getAllItineraries().find { it.id == id }
   }
 }

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -35,6 +35,7 @@ class MapViewModel(
         MutableLiveData<Map<Itinerary, List<LatLng>>>()
 ) : ViewModel() {
 
+  // Dummy selected polyline to avoid nullability issues
   val DUMMY_SELECTED_POLYLINE =
       SelectedPolyline(
           Itinerary("", "", "", Location(0.0, 0.0, ""), 0, "", "", emptyList(), "", emptyList()),


### PR DESCRIPTION
This PR will : 
- Fix navigation bugs when going from home to maps when clicking on a path. The camera will be centered on the selected path, display it as if it was clicked and show the pop up.
- Allow to click on an itinerary in the search bar so that it navigates directly to it's map overview.
- Navigating between home and Maps now resets the stored states and is not crashing anymore.
- Now clicking on the map in the map overview unselect the path if there was one selected and displayed in bold.
- Add spot was changed in order to match the figma design.
- Tests are fixed.
- Now clicking on the pop up of a path opens the path overview with all the spots in full screen width.
- Clicking on one of these pins opens the pin description and shows the picture.

<image src = https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/79469048/02ed1fbf-7684-4099-a8bf-1ca1e6763282 width = 300> <image src = https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/79469048/12eb7fcd-7802-44c6-b476-cde45bff0d99 width = 300>

