### PR TITLE
Map start screen

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
@@ -11,6 +11,7 @@ import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.map.StartScreen
+import com.example.triptracker.viewmodel.UserProfileViewModel
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +19,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class StartScreenTest {
 
+  val userViewModel = UserProfileViewModel()
   val pin1 = Pin(50.05186463055543, 14.43129605385369, "HQ", "Jetbrains HQ", emptyList())
   val pin2 = Pin(50.0792573623994, 14.418225529534855, "U Fleku", "Oldest restaurant", emptyList())
   val pin3 = Pin(50.08731011666294, 14.420438033846013, "Clock", "Astronomical Clock", emptyList())
@@ -52,7 +54,7 @@ class StartScreenTest {
   @Test
   fun userAvatarIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithTag("ProfilePic").assertIsDisplayed()
   }
@@ -60,7 +62,7 @@ class StartScreenTest {
   @Test
   fun usernameIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithTag("Username").assertTextEquals("json@kotlin.com")
   }
@@ -68,7 +70,7 @@ class StartScreenTest {
   @Test
   fun itineraryTitleIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithTag("Title").assertTextEquals(sampleItinerary.title)
   }
@@ -76,7 +78,7 @@ class StartScreenTest {
   @Test
   fun flameCountIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithText("${sampleItinerary.flameCount}🔥").assertIsDisplayed()
   }
@@ -84,7 +86,7 @@ class StartScreenTest {
   @Test
   fun startButtonIsDisplayedAndClickable() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithText("Start").assertIsDisplayed()
   }

--- a/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
@@ -1,0 +1,91 @@
+package com.example.triptracker.map
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.triptracker.model.itinerary.Itinerary
+import com.example.triptracker.model.location.Location
+import com.example.triptracker.model.location.Pin
+import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.view.map.StartScreen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class StartScreenTest {
+
+  val pin1 = Pin(50.05186463055543, 14.43129605385369, "HQ", "Jetbrains HQ", emptyList())
+  val pin2 = Pin(50.0792573623994, 14.418225529534855, "U Fleku", "Oldest restaurant", emptyList())
+  val pin3 = Pin(50.08731011666294, 14.420438033846013, "Clock", "Astronomical Clock", emptyList())
+
+  val loc = Location(50.05186463055543, 14.43129605385369, "HQ")
+  val sampleItinerary =
+      Itinerary(
+          "1",
+          "Jetbrains Island",
+          "json@kotlin.com",
+          loc,
+          500,
+          "4",
+          "5",
+          listOf(pin1, pin2, pin3),
+          "test",
+          emptyList())
+  val profile =
+      UserProfile(
+          "pol@gmail.com",
+          "Foo",
+          "Fighter",
+          "29/12/1999",
+          "",
+          "",
+          emptyList(),
+          emptyList(),
+      )
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Test
+  fun userAvatarIsDisplayed() {
+    composeTestRule.setContent {
+      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+    }
+    composeTestRule.onNodeWithTag("ProfilePic").assertIsDisplayed()
+  }
+
+  @Test
+  fun usernameIsDisplayed() {
+    composeTestRule.setContent {
+      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+    }
+    composeTestRule.onNodeWithTag("Username").assertTextEquals("json@kotlin.com")
+  }
+
+  @Test
+  fun itineraryTitleIsDisplayed() {
+    composeTestRule.setContent {
+      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+    }
+    composeTestRule.onNodeWithTag("Title").assertTextEquals(sampleItinerary.title)
+  }
+
+  @Test
+  fun flameCountIsDisplayed() {
+    composeTestRule.setContent {
+      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+    }
+    composeTestRule.onNodeWithText("${sampleItinerary.flameCount}🔥").assertIsDisplayed()
+  }
+
+  @Test
+  fun startButtonIsDisplayedAndClickable() {
+    composeTestRule.setContent {
+      StartScreen(itinerary = sampleItinerary, profile = profile, onClick = {})
+    }
+    composeTestRule.onNodeWithText("Start").assertIsDisplayed()
+  }
+}

--- a/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
@@ -12,6 +12,9 @@ import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.map.StartScreen
 import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +22,15 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class StartScreenTest {
 
-  val userViewModel = UserProfileViewModel()
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @RelaxedMockK private lateinit var userViewModel: UserProfileViewModel
+
+  @Before
+  fun setUp() {
+    userViewModel = mockk(relaxed = true)
+  }
+
   val pin1 = Pin(50.05186463055543, 14.43129605385369, "HQ", "Jetbrains HQ", emptyList())
   val pin2 = Pin(50.0792573623994, 14.418225529534855, "U Fleku", "Oldest restaurant", emptyList())
   val pin3 = Pin(50.08731011666294, 14.420438033846013, "Clock", "Astronomical Clock", emptyList())
@@ -29,7 +40,7 @@ class StartScreenTest {
       Itinerary(
           "1",
           "Jetbrains Island",
-          "json@kotlin.com",
+          "polfuentescam@gmail.com",
           loc,
           500,
           "4",
@@ -49,8 +60,6 @@ class StartScreenTest {
           emptyList(),
       )
 
-  @get:Rule val composeTestRule = createComposeRule()
-
   @Test
   fun userAvatarIsDisplayed() {
     composeTestRule.setContent {
@@ -59,6 +68,9 @@ class StartScreenTest {
     composeTestRule.onNodeWithTag("ProfilePic").assertIsDisplayed()
   }
 
+  // Commented out because the username is not displayed in the StartScreen
+  // Name not being fetched from DB
+  /*
   @Test
   fun usernameIsDisplayed() {
     composeTestRule.setContent {
@@ -66,6 +78,7 @@ class StartScreenTest {
     }
     composeTestRule.onNodeWithTag("Username").assertTextEquals("json@kotlin.com")
   }
+  */
 
   @Test
   fun itineraryTitleIsDisplayed() {

--- a/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
@@ -12,7 +12,10 @@ import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.map.StartScreen
 import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.just
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
@@ -29,6 +32,21 @@ class StartScreenTest {
   @Before
   fun setUp() {
     userViewModel = mockk(relaxed = true)
+
+    userViewModel = mockk {
+      coEvery { fetchAllUserProfiles(any()) } just io.mockk.Runs
+      coEvery { getUserProfileList() } returns listOf()
+      coEvery { getUserProfile(any(), any()) } coAnswers
+          {
+            secondArg<(UserProfile?) -> Unit>()
+                .invoke(UserProfile("polfuentescam@gmail.com", "Pol", "", ""))
+          }
+      coEvery { addNewUserProfileToDb(any()) } just io.mockk.Runs
+      coEvery { updateUserProfileInDb(any()) } just io.mockk.Runs
+      coEvery { addFollower(any(), any()) } just io.mockk.Runs
+      coEvery { removeFollower(any(), any()) } just io.mockk.Runs
+      coEvery { removeUserProfileInDb(any()) } just io.mockk.Runs
+    }
   }
 
   val pin1 = Pin(50.05186463055543, 14.43129605385369, "HQ", "Jetbrains HQ", emptyList())
@@ -68,17 +86,13 @@ class StartScreenTest {
     composeTestRule.onNodeWithTag("ProfilePic").assertIsDisplayed()
   }
 
-  // Commented out because the username is not displayed in the StartScreen
-  // Name not being fetched from DB
-  /*
   @Test
   fun usernameIsDisplayed() {
     composeTestRule.setContent {
       StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
     }
-    composeTestRule.onNodeWithTag("Username").assertTextEquals("json@kotlin.com")
+    composeTestRule.onNodeWithTag("Username").assertTextEquals("Pol")
   }
-  */
 
   @Test
   fun itineraryTitleIsDisplayed() {

--- a/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/StartScreenTest.kt
@@ -81,7 +81,7 @@ class StartScreenTest {
   @Test
   fun userAvatarIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
+      StartScreen(itinerary = sampleItinerary, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithTag("ProfilePic").assertIsDisplayed()
   }
@@ -89,7 +89,7 @@ class StartScreenTest {
   @Test
   fun usernameIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
+      StartScreen(itinerary = sampleItinerary, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithTag("Username").assertTextEquals("Pol")
   }
@@ -97,7 +97,7 @@ class StartScreenTest {
   @Test
   fun itineraryTitleIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
+      StartScreen(itinerary = sampleItinerary, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithTag("Title").assertTextEquals(sampleItinerary.title)
   }
@@ -105,7 +105,7 @@ class StartScreenTest {
   @Test
   fun flameCountIsDisplayed() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
+      StartScreen(itinerary = sampleItinerary, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithText("${sampleItinerary.flameCount}🔥").assertIsDisplayed()
   }
@@ -113,7 +113,7 @@ class StartScreenTest {
   @Test
   fun startButtonIsDisplayedAndClickable() {
     composeTestRule.setContent {
-      StartScreen(itinerary = sampleItinerary, profile = profile, userViewModel, onClick = {})
+      StartScreen(itinerary = sampleItinerary, userViewModel, onClick = {})
     }
     composeTestRule.onNodeWithText("Start").assertIsDisplayed()
   }

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -363,11 +363,9 @@ fun Map(
                   DisplayItinerary(
                       itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
                       navigation = navigation,
-                      onClick = { mapPopupState = popupState.PATHOVERLAY },
+                      onClick = { mapPopupState = popupState.DISPLAYPIN },
                       test = false,
                       profile = userProfile)
-                      onClick = { mapPopupState = popupState.DISPLAYPIN },
-                      test = false)
                 }
           }
           popupState.DISPLAYPIN -> {

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -55,6 +55,7 @@ import com.example.triptracker.view.theme.md_theme_light_onPrimary
 import com.example.triptracker.view.theme.md_theme_light_outline
 import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.MapViewModel
+import com.example.triptracker.viewmodel.UserProfileViewModel
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.VisibleRegion
@@ -352,12 +353,20 @@ fun Map(
                   DisplayItinerary(
                       itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
                       navigation = navigation,
-                      onClick = { mapPopupState = popupState.PATHOVERLAY },
+                      onClick = { mapPopupState = popupState.DISPLAYPIN },
                       test = false)
                 }
           }
           popupState.DISPLAYPIN -> {
-            // called detailed view Theo
+              Box(
+                  modifier =
+                  Modifier.fillMaxHeight().fillMaxWidth().align(Alignment.BottomCenter)) {
+                  StartScreen(
+                      itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
+                      uservm = UserProfileViewModel(),
+                      onClick = { mapPopupState = popupState.PATHOVERLAY }
+                  )
+              }
           }
           popupState.PATHOVERLAY -> {
             Box(

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -358,15 +358,12 @@ fun Map(
                 }
           }
           popupState.DISPLAYPIN -> {
-              Box(
-                  modifier =
-                  Modifier.fillMaxHeight().fillMaxWidth().align(Alignment.BottomCenter)) {
-                  StartScreen(
-                      itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
-                      uservm = UserProfileViewModel(),
-                      onClick = { mapPopupState = popupState.PATHOVERLAY }
-                  )
-              }
+            Box(modifier = Modifier.fillMaxHeight().fillMaxWidth().align(Alignment.BottomCenter)) {
+              StartScreen(
+                  itinerary = mapViewModel.selectedPolylineState.value!!.itinerary,
+                  uservm = UserProfileViewModel(),
+                  onClick = { mapPopupState = popupState.PATHOVERLAY })
+            }
           }
           popupState.PATHOVERLAY -> {
             Box(

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
@@ -38,6 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.Font
@@ -157,64 +159,17 @@ fun AddressText(mpv: MapPopupViewModel, latitude: Float, longitude: Float) {
   Text(text = address, color = Color.White, modifier = Modifier.testTag("AddressText"))
 }
 
-@Preview
-@Composable
-fun DisplayStartScreen() {
-  // test itin
-  val pin1 =
-      Pin(
-          50.05186463055543,
-          14.43129605385369,
-          "HQ",
-          "Jetbrains HQ",
-          listOf(
-              "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg",
-              "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg",
-              "https://cdn-vsh.prague.eu/object/254/u-fleku-01.jpg"))
-  val pin2 =
-      Pin(
-          50.0792573623994,
-          14.418225529534855,
-          "U Fleku",
-          "Oldest restaurant",
-          listOf(
-              "https://d3dqioy2sca31t.cloudfront.net/Projects/cms/production/000/033/186/slideshow/aa3cc8bc14fc3f93c823f6aa5743874e/slide-czech-republic-prague-old-town-hall.jpg"))
-  val pin3 = Pin(50.08731011666294, 14.420438033846013, "Clock", "Astronomical Clock", emptyList())
-
-  val loc = Location(50.05186463055543, 14.43129605385369, "HQ")
-  val itin =
-      Itinerary(
-          "1",
-          "Jetbrains Island",
-          "polfuentescam@gmail.com",
-          loc,
-          500,
-          "4",
-          "5",
-          listOf(pin1, pin2, pin3),
-          "test",
-          emptyList())
-  val profile =
-      UserProfile(
-          "pol@gmail.com",
-          "Foo",
-          "Fighter",
-          "29/12/1999",
-          "",
-          "",
-          emptyList(),
-          emptyList(),
-      )
-  StartScreen(itin, profile, UserProfileViewModel(), onClick = {})
-}
 
 @Composable
 fun StartScreen(
     itinerary: Itinerary,
-    profile: UserProfile,
     uservm: UserProfileViewModel,
-    onClick: (Pin) -> Unit
+    onClick: () -> Unit
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = configuration.screenWidthDp.dp
+    val screenHeight = configuration.screenHeightDp.dp
+
   // The size of the user's avatar/profile picture
   val avatarSize = 35.dp
   var userofpost by remember { mutableStateOf(UserProfile("")) }
@@ -246,6 +201,7 @@ fun StartScreen(
                 modifier =
                     Modifier.size(avatarSize)
                         .clip(CircleShape)
+                        .sizeIn(maxWidth = 20.dp)
                         .testTag("ProfilePic")
                         .clickable { /* TODO bring user to profile page */})
 
@@ -285,10 +241,12 @@ fun StartScreen(
                       bottom = 20.dp,
                       top = 10.dp,
                   ))
-          Column(
+          LazyColumn(
               modifier =
-                  Modifier.padding(top = 10.dp, start = 10.dp, end = 10.dp, bottom = 50.dp)) {
-                for (pin in itinerary.pinnedPlaces) {
+                  Modifier.padding(top = 10.dp, start = 10.dp, end = 10.dp, bottom = 40.dp)
+                      .size(screenWidth, screenHeight * 0.08f)
+          ) {
+                    items(itinerary.pinnedPlaces) { pin ->
                   Text(text = "• ${pin.name}", color = md_theme_grey, fontSize = 20.sp)
                   Spacer(modifier = Modifier.height(3.dp))
                 }
@@ -300,33 +258,39 @@ fun StartScreen(
                 AsyncImage(
                     model = image,
                     contentDescription = pin.description,
-                    modifier = Modifier.clip(RoundedCornerShape(corner = CornerSize(12.dp))))
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(corner = CornerSize(14.dp)))
+                        .size(screenWidth * 0.9f, screenHeight * 0.3f)
 
-                Spacer(modifier = Modifier.width(15.dp))
+                )
+
+                Spacer(modifier = Modifier.width(20.dp))
               }
             }
           }
-        }
-
-        Button(
-            onClick = { /* Do something! */},
-            modifier =
-                Modifier.align(Alignment.BottomCenter)
-                    .padding(bottom = 40.dp)
+            Button(
+                onClick = { onClick() },
+                modifier =
+                Modifier
+                    .padding(bottom = 30.dp, top = 10.dp)
+                    .align(Alignment.CenterHorizontally)
                     .height(56.dp) // Set a specific height for the button to make it larger
                     .fillMaxWidth(fraction = 0.5f), // Make the button fill 90% of the width
-            shape = RoundedCornerShape(35.dp),
-            colors =
+                shape = RoundedCornerShape(35.dp),
+                colors =
                 ButtonDefaults.buttonColors(
                     backgroundColor = Color(0xFFF06F24),
                 ) // Rounded corners with a radius of 12.dp
             ) {
-              Text(
-                  "Start",
-                  fontSize = 24.sp,
-                  color = Color.White,
-                  fontFamily = Montserrat,
-                  fontWeight = FontWeight.Bold)
+                Text(
+                    "Start",
+                    fontSize = 24.sp,
+                    color = Color.White,
+                    fontFamily = Montserrat,
+                    fontWeight = FontWeight.Bold)
             }
+        }
+
+
       }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -30,11 +32,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
+import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_light_black
 import com.example.triptracker.view.theme.md_theme_light_onPrimary
 import com.example.triptracker.viewmodel.MapPopupViewModel
@@ -68,12 +75,17 @@ fun PathOverlaySheet(
     else -> {
       Box(
           modifier =
-              Modifier.fillMaxWidth()
-                  .fillMaxHeight()
-                  .background(
-                      color = md_theme_light_black,
-                      shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp))) {
-            Column(modifier = Modifier.fillMaxWidth().testTag("PathOverlaySheet").padding(25.dp)) {
+          Modifier
+              .fillMaxWidth()
+              .fillMaxHeight()
+              .background(
+                  color = md_theme_light_black,
+                  shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp)
+              )) {
+            Column(modifier = Modifier
+                .fillMaxWidth()
+                .testTag("PathOverlaySheet")
+                .padding(25.dp)) {
               Text(
                   text = profile.username + "'s Path",
                   color = md_theme_light_onPrimary,
@@ -103,14 +115,18 @@ fun PathOverlaySheet(
 fun PathItem(pinnedPlace: Pin, onClick: (Pin) -> Unit) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier.clickable { onClick(pinnedPlace) }.testTag("PathItem")) {
+      modifier = Modifier
+          .clickable { onClick(pinnedPlace) }
+          .testTag("PathItem")) {
         Icon(
             painter =
                 painterResource(
                     id = R.drawable.ic_gps_fixed), // Replace with your actual pin icon resource
             contentDescription = "Location pin",
             tint = Color.White)
-        Column(modifier = Modifier.weight(1f).padding(start = 16.dp)) {
+        Column(modifier = Modifier
+            .weight(1f)
+            .padding(start = 16.dp)) {
           Text(text = pinnedPlace.name, color = Color.White)
           // Fetch address
           AddressText(
@@ -135,4 +151,62 @@ fun AddressText(mpv: MapPopupViewModel, latitude: Float, longitude: Float) {
   LaunchedEffect(key1 = latitude, key2 = longitude) { mpv.fetchAddressForPin(latitude, longitude) }
 
   Text(text = address, color = Color.White, modifier = Modifier.testTag("AddressText"))
+}
+
+@Preview
+@Composable
+fun DisplayStartScreen() {
+  // test itin
+  val loc = Location(0.0, 0.0, "")
+  val itin = Itinerary("", "", "", loc, 0, "", "", emptyList(), "", emptyList())
+  val profile = UserProfile("")
+  StartScreen(itin, profile, onClick = {})
+}
+
+@Composable
+fun StartScreen(itinerary: Itinerary, profile: UserProfile, onClick: (Pin) -> Unit) {
+
+  Box(
+      modifier =
+      Modifier
+          .fillMaxWidth()
+          .fillMaxHeight()
+          .background(
+              color = md_theme_light_black,
+              shape =
+              RoundedCornerShape(
+                  topStart = 35.dp,
+                  topEnd = 35.dp,
+                  bottomStart = 35.dp,
+                  bottomEnd = 35.dp
+              )
+          )) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .testTag("PathOverlaySheet")
+            .padding(25.dp)) {
+          Text(
+              text = profile.username + "'s Path",
+              color = md_theme_light_onPrimary,
+              modifier = Modifier.padding(end = 10.dp))
+          Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        Button(
+
+            onClick = { /* Do something! */},
+            modifier =
+            Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 40.dp)
+                .height(56.dp) // Set a specific height for the button to make it larger
+                .fillMaxWidth(fraction = 0.5f), // Make the button fill 90% of the width
+            shape = RoundedCornerShape(35.dp),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = Color(0xFFF06F24),
+            ) // Rounded corners with a radius of 12.dp
+        ) {
+          Text("Start", fontSize = 24.sp, color = Color.White, fontFamily = Montserrat, fontWeight = FontWeight.Bold)
+        }
+      }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -12,14 +12,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Star
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -29,21 +34,27 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.theme.Montserrat
+import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_black
 import com.example.triptracker.view.theme.md_theme_light_onPrimary
+import com.example.triptracker.view.theme.md_theme_orange
 import com.example.triptracker.viewmodel.MapPopupViewModel
 import com.example.triptracker.viewmodel.UserProfileViewModel
 
@@ -75,17 +86,12 @@ fun PathOverlaySheet(
     else -> {
       Box(
           modifier =
-          Modifier
-              .fillMaxWidth()
-              .fillMaxHeight()
-              .background(
-                  color = md_theme_light_black,
-                  shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp)
-              )) {
-            Column(modifier = Modifier
-                .fillMaxWidth()
-                .testTag("PathOverlaySheet")
-                .padding(25.dp)) {
+              Modifier.fillMaxWidth()
+                  .fillMaxHeight()
+                  .background(
+                      color = md_theme_light_black,
+                      shape = RoundedCornerShape(topStart = 35.dp, topEnd = 35.dp))) {
+            Column(modifier = Modifier.fillMaxWidth().testTag("PathOverlaySheet").padding(25.dp)) {
               Text(
                   text = profile.username + "'s Path",
                   color = md_theme_light_onPrimary,
@@ -115,18 +121,14 @@ fun PathOverlaySheet(
 fun PathItem(pinnedPlace: Pin, onClick: (Pin) -> Unit) {
   Row(
       verticalAlignment = Alignment.CenterVertically,
-      modifier = Modifier
-          .clickable { onClick(pinnedPlace) }
-          .testTag("PathItem")) {
+      modifier = Modifier.clickable { onClick(pinnedPlace) }.testTag("PathItem")) {
         Icon(
             painter =
                 painterResource(
                     id = R.drawable.ic_gps_fixed), // Replace with your actual pin icon resource
             contentDescription = "Location pin",
             tint = Color.White)
-        Column(modifier = Modifier
-            .weight(1f)
-            .padding(start = 16.dp)) {
+        Column(modifier = Modifier.weight(1f).padding(start = 16.dp)) {
           Text(text = pinnedPlace.name, color = Color.White)
           // Fetch address
           AddressText(
@@ -157,56 +159,150 @@ fun AddressText(mpv: MapPopupViewModel, latitude: Float, longitude: Float) {
 @Composable
 fun DisplayStartScreen() {
   // test itin
-  val loc = Location(0.0, 0.0, "")
-  val itin = Itinerary("", "", "", loc, 0, "", "", emptyList(), "", emptyList())
-  val profile = UserProfile("")
+  val pin1 =
+      Pin(
+          50.05186463055543,
+          14.43129605385369,
+          "HQ",
+          "Jetbrains HQ",
+          listOf(
+              "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg"))
+  val pin2 =
+      Pin(
+          50.0792573623994,
+          14.418225529534855,
+          "U Fleku",
+          "Oldest restaurant",
+          listOf(
+              "https://www.minecraft.net/content/dam/games/minecraft/key-art/Player-Parent-Onboarding_Carousel-Before-You-Begin_Create-a-Minecraft-Acct_1280x768.jpg"))
+  val pin3 = Pin(50.08731011666294, 14.420438033846013, "Clock", "Astronomical Clock", emptyList())
+
+  val loc = Location(50.05186463055543, 14.43129605385369, "HQ")
+  val itin =
+      Itinerary(
+          "1",
+          "Jetbrains Island",
+          "json@kotlin.com",
+          loc,
+          500,
+          "4",
+          "5",
+          listOf(pin1, pin2, pin3),
+          "test",
+          emptyList())
+  val profile =
+      UserProfile(
+          "pol@gmail.com",
+          "Foo",
+          "Fighter",
+          "29/12/1999",
+          "",
+          "",
+          emptyList(),
+          emptyList(),
+      )
   StartScreen(itin, profile, onClick = {})
 }
 
 @Composable
 fun StartScreen(itinerary: Itinerary, profile: UserProfile, onClick: (Pin) -> Unit) {
+  // The size of the user's avatar/profile picture
+  val avatarSize = 30.dp
 
   Box(
       modifier =
-      Modifier
-          .fillMaxWidth()
-          .fillMaxHeight()
-          .background(
-              color = md_theme_light_black,
-              shape =
-              RoundedCornerShape(
-                  topStart = 35.dp,
-                  topEnd = 35.dp,
-                  bottomStart = 35.dp,
-                  bottomEnd = 35.dp
-              )
-          )) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .testTag("PathOverlaySheet")
-            .padding(25.dp)) {
+          Modifier.fillMaxWidth()
+              .fillMaxHeight()
+              .background(
+                  color = md_theme_light_black,
+                  shape =
+                      RoundedCornerShape(
+                          topStart = 35.dp,
+                          topEnd = 35.dp,
+                          bottomStart = 35.dp,
+                          bottomEnd = 35.dp))) {
+        Column(modifier = Modifier.fillMaxWidth().padding(25.dp).padding(top = 30.dp)) {
+          Row(modifier = Modifier.fillMaxWidth()) {
+            // change the image to the user's profile picture
+            AsyncImage(
+                model = profile.profileImageUrl,
+                contentDescription = "User Avatar",
+                modifier =
+                    Modifier.size(avatarSize)
+                        .clip(CircleShape)
+                        .testTag("ProfilePic")
+                        .clickable { /* TODO bring user to profile page */})
+
+            Spacer(modifier = Modifier.width(15.dp))
+            Text(
+                text = itinerary.userMail,
+                fontFamily = FontFamily(Font(R.font.montserrat_regular)),
+                //                wrapContentHeight(align = Alignment.CenterVertically),
+                fontWeight = FontWeight.Normal,
+                fontSize = 18.sp,
+                color = md_theme_grey,
+                modifier = Modifier.testTag("Username"))
+            Spacer(modifier = Modifier.width(120.dp))
+            Icon(
+                imageVector = Icons.Outlined.Star,
+                contentDescription = "Star",
+                Modifier.size(30.dp))
+          }
+          Spacer(modifier = Modifier.height(20.dp))
           Text(
-              text = profile.username + "'s Path",
+              text = itinerary.title,
+              fontFamily = FontFamily(Font(R.font.montserrat_regular)),
+              fontWeight = FontWeight.Bold,
+              fontSize = 30.sp,
               color = md_theme_light_onPrimary,
-              modifier = Modifier.padding(end = 10.dp))
-          Spacer(modifier = Modifier.height(16.dp))
+              modifier = Modifier.testTag("Title"))
+          Text(
+              text = "${itinerary.flameCount}🔥",
+              color = md_theme_orange, // This is the orange color
+              fontFamily = FontFamily(Font(R.font.montserrat_regular)),
+              fontSize = 20.sp,
+              modifier =
+                  Modifier.padding(
+                      bottom = 20.dp,
+                      top = 10.dp,
+                  ))
+          Column(
+              modifier =
+                  Modifier.padding(top = 10.dp, start = 10.dp, end = 10.dp, bottom = 50.dp)) {
+                for (pin in itinerary.pinnedPlaces) {
+                  Text(text = "• ${pin.name}", color = md_theme_grey, fontSize = 20.sp)
+                  Spacer(modifier = Modifier.height(3.dp))
+                }
+              }
+
+          LazyRow {
+            items(itinerary.pinnedPlaces) { pin ->
+              for (image in pin.image_url) {
+                AsyncImage(model = image, contentDescription = pin.description)
+              }
+            }
+          }
         }
 
         Button(
-
             onClick = { /* Do something! */},
             modifier =
-            Modifier
-                .align(Alignment.BottomCenter)
-                .padding(bottom = 40.dp)
-                .height(56.dp) // Set a specific height for the button to make it larger
-                .fillMaxWidth(fraction = 0.5f), // Make the button fill 90% of the width
+                Modifier.align(Alignment.BottomCenter)
+                    .padding(bottom = 40.dp)
+                    .height(56.dp) // Set a specific height for the button to make it larger
+                    .fillMaxWidth(fraction = 0.5f), // Make the button fill 90% of the width
             shape = RoundedCornerShape(35.dp),
-            colors = ButtonDefaults.buttonColors(
-                backgroundColor = Color(0xFFF06F24),
-            ) // Rounded corners with a radius of 12.dp
-        ) {
-          Text("Start", fontSize = 24.sp, color = Color.White, fontFamily = Montserrat, fontWeight = FontWeight.Bold)
-        }
+            colors =
+                ButtonDefaults.buttonColors(
+                    backgroundColor = Color(0xFFF06F24),
+                ) // Rounded corners with a radius of 12.dp
+            ) {
+              Text(
+                  "Start",
+                  fontSize = 24.sp,
+                  color = Color.White,
+                  fontFamily = Montserrat,
+                  fontWeight = FontWeight.Bold)
+            }
       }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -45,13 +45,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
-import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.theme.Montserrat
@@ -159,16 +157,11 @@ fun AddressText(mpv: MapPopupViewModel, latitude: Float, longitude: Float) {
   Text(text = address, color = Color.White, modifier = Modifier.testTag("AddressText"))
 }
 
-
 @Composable
-fun StartScreen(
-    itinerary: Itinerary,
-    uservm: UserProfileViewModel,
-    onClick: () -> Unit
-) {
-    val configuration = LocalConfiguration.current
-    val screenWidth = configuration.screenWidthDp.dp
-    val screenHeight = configuration.screenHeightDp.dp
+fun StartScreen(itinerary: Itinerary, uservm: UserProfileViewModel, onClick: () -> Unit) {
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp.dp
+  val screenHeight = configuration.screenHeightDp.dp
 
   // The size of the user's avatar/profile picture
   val avatarSize = 35.dp
@@ -244,9 +237,8 @@ fun StartScreen(
           LazyColumn(
               modifier =
                   Modifier.padding(top = 10.dp, start = 10.dp, end = 10.dp, bottom = 40.dp)
-                      .size(screenWidth, screenHeight * 0.08f)
-          ) {
-                    items(itinerary.pinnedPlaces) { pin ->
+                      .size(screenWidth, screenHeight * 0.08f)) {
+                items(itinerary.pinnedPlaces) { pin ->
                   Text(text = "• ${pin.name}", color = md_theme_grey, fontSize = 20.sp)
                   Spacer(modifier = Modifier.height(3.dp))
                 }
@@ -258,39 +250,34 @@ fun StartScreen(
                 AsyncImage(
                     model = image,
                     contentDescription = pin.description,
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(corner = CornerSize(14.dp)))
-                        .size(screenWidth * 0.9f, screenHeight * 0.3f)
-
-                )
+                    modifier =
+                        Modifier.clip(RoundedCornerShape(corner = CornerSize(14.dp)))
+                            .size(screenWidth * 0.9f, screenHeight * 0.3f))
 
                 Spacer(modifier = Modifier.width(20.dp))
               }
             }
           }
-            Button(
-                onClick = { onClick() },
-                modifier =
-                Modifier
-                    .padding(bottom = 30.dp, top = 10.dp)
-                    .align(Alignment.CenterHorizontally)
-                    .height(56.dp) // Set a specific height for the button to make it larger
-                    .fillMaxWidth(fraction = 0.5f), // Make the button fill 90% of the width
-                shape = RoundedCornerShape(35.dp),
-                colors =
-                ButtonDefaults.buttonColors(
-                    backgroundColor = Color(0xFFF06F24),
-                ) // Rounded corners with a radius of 12.dp
-            ) {
+          Button(
+              onClick = { onClick() },
+              modifier =
+                  Modifier.padding(bottom = 30.dp, top = 10.dp)
+                      .align(Alignment.CenterHorizontally)
+                      .height(56.dp) // Set a specific height for the button to make it larger
+                      .fillMaxWidth(fraction = 0.5f), // Make the button fill 90% of the width
+              shape = RoundedCornerShape(35.dp),
+              colors =
+                  ButtonDefaults.buttonColors(
+                      backgroundColor = Color(0xFFF06F24),
+                  ) // Rounded corners with a radius of 12.dp
+              ) {
                 Text(
                     "Start",
                     fontSize = 24.sp,
                     color = Color.White,
                     fontFamily = Montserrat,
                     fontWeight = FontWeight.Bold)
-            }
+              }
         }
-
-
       }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -50,7 +51,6 @@ import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
-import com.example.triptracker.model.profile.EMPTY_PROFILE
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
@@ -169,6 +169,7 @@ fun DisplayStartScreen() {
           "Jetbrains HQ",
           listOf(
               "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg",
+              "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg",
               "https://cdn-vsh.prague.eu/object/254/u-fleku-01.jpg"))
   val pin2 =
       Pin(
@@ -215,8 +216,9 @@ fun StartScreen(
     onClick: (Pin) -> Unit
 ) {
   // The size of the user's avatar/profile picture
-  val avatarSize = 30.dp
-  var userofpost: UserProfile = EMPTY_PROFILE
+  val avatarSize = 35.dp
+  var userofpost by remember { mutableStateOf(UserProfile("")) }
+
   uservm.getUserProfile(itinerary.userMail) { itin ->
     if (itin != null) {
       userofpost = itin
@@ -239,7 +241,7 @@ fun StartScreen(
           Row(modifier = Modifier.fillMaxWidth()) {
             // change the image to the user's profile picture
             AsyncImage(
-                model = profile.profileImageUrl,
+                model = userofpost.profileImageUrl,
                 contentDescription = "User Avatar",
                 modifier =
                     Modifier.size(avatarSize)
@@ -255,12 +257,15 @@ fun StartScreen(
                 fontWeight = FontWeight.Normal,
                 fontSize = 18.sp,
                 color = md_theme_grey,
-                modifier = Modifier.testTag("Username"))
-            Spacer(modifier = Modifier.width(120.dp))
+                modifier =
+                    Modifier.testTag("Username")
+                        .wrapContentHeight(align = Alignment.CenterVertically))
+            Spacer(Modifier.weight(1f))
+
             Icon(
                 imageVector = Icons.Outlined.Star,
                 contentDescription = "Star",
-                Modifier.size(30.dp))
+                Modifier.size(40.dp))
           }
           Spacer(modifier = Modifier.height(20.dp))
           Text(

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -167,7 +168,8 @@ fun DisplayStartScreen() {
           "HQ",
           "Jetbrains HQ",
           listOf(
-              "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg"))
+              "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Prague_%286365119737%29.jpg/800px-Prague_%286365119737%29.jpg",
+              "https://cdn-vsh.prague.eu/object/254/u-fleku-01.jpg"))
   val pin2 =
       Pin(
           50.0792573623994,
@@ -175,7 +177,7 @@ fun DisplayStartScreen() {
           "U Fleku",
           "Oldest restaurant",
           listOf(
-              "https://www.minecraft.net/content/dam/games/minecraft/key-art/Player-Parent-Onboarding_Carousel-Before-You-Begin_Create-a-Minecraft-Acct_1280x768.jpg"))
+              "https://d3dqioy2sca31t.cloudfront.net/Projects/cms/production/000/033/186/slideshow/aa3cc8bc14fc3f93c823f6aa5743874e/slide-czech-republic-prague-old-town-hall.jpg"))
   val pin3 = Pin(50.08731011666294, 14.420438033846013, "Clock", "Astronomical Clock", emptyList())
 
   val loc = Location(50.05186463055543, 14.43129605385369, "HQ")
@@ -183,7 +185,7 @@ fun DisplayStartScreen() {
       Itinerary(
           "1",
           "Jetbrains Island",
-          "sd.shurtugal@gmail.com",
+          "polfuentescam@gmail.com",
           loc,
           500,
           "4",
@@ -290,7 +292,12 @@ fun StartScreen(
           LazyRow {
             items(itinerary.pinnedPlaces) { pin ->
               for (image in pin.image_url) {
-                AsyncImage(model = image, contentDescription = pin.description)
+                AsyncImage(
+                    model = image,
+                    contentDescription = pin.description,
+                    modifier = Modifier.clip(RoundedCornerShape(corner = CornerSize(12.dp))))
+
+                Spacer(modifier = Modifier.width(15.dp))
               }
             }
           }

--- a/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapPopups.kt
@@ -49,6 +49,7 @@ import com.example.triptracker.R
 import com.example.triptracker.model.itinerary.Itinerary
 import com.example.triptracker.model.location.Location
 import com.example.triptracker.model.location.Pin
+import com.example.triptracker.model.profile.EMPTY_PROFILE
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
@@ -182,7 +183,7 @@ fun DisplayStartScreen() {
       Itinerary(
           "1",
           "Jetbrains Island",
-          "json@kotlin.com",
+          "sd.shurtugal@gmail.com",
           loc,
           500,
           "4",
@@ -201,13 +202,24 @@ fun DisplayStartScreen() {
           emptyList(),
           emptyList(),
       )
-  StartScreen(itin, profile, onClick = {})
+  StartScreen(itin, profile, UserProfileViewModel(), onClick = {})
 }
 
 @Composable
-fun StartScreen(itinerary: Itinerary, profile: UserProfile, onClick: (Pin) -> Unit) {
+fun StartScreen(
+    itinerary: Itinerary,
+    profile: UserProfile,
+    uservm: UserProfileViewModel,
+    onClick: (Pin) -> Unit
+) {
   // The size of the user's avatar/profile picture
   val avatarSize = 30.dp
+  var userofpost: UserProfile = EMPTY_PROFILE
+  uservm.getUserProfile(itinerary.userMail) { itin ->
+    if (itin != null) {
+      userofpost = itin
+    }
+  }
 
   Box(
       modifier =
@@ -235,7 +247,7 @@ fun StartScreen(itinerary: Itinerary, profile: UserProfile, onClick: (Pin) -> Un
 
             Spacer(modifier = Modifier.width(15.dp))
             Text(
-                text = itinerary.userMail,
+                text = userofpost.name,
                 fontFamily = FontFamily(Font(R.font.montserrat_regular)),
                 //                wrapContentHeight(align = Alignment.CenterVertically),
                 fontWeight = FontWeight.Normal,


### PR DESCRIPTION
Startscreen working:

- UserImage displayed
- User name displayed
- flamecount displayed
- pins displayed
- images displayed

Next steps: implement it into the flow of the app
Tests passed with mock db, no cloud Firestore this time 
TODO: Star is black for some reason, even though one selected is outlined

EDIT:
Integrated into flow of the app
Removed preview composable
resized so images don't take up the whole screen size, same for list of pins

<img width="225" alt="Screenshot 2024-05-09 at 14 17 26" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/68853181/24b75747-8606-4b53-8278-127652ec3244">


