### PR TITLE
Addspot update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -155,8 +155,9 @@ dependencies {
   implementation("androidx.compose.runtime:runtime")
   implementation("androidx.compose.runtime:runtime-rxjava2")
   implementation("androidx.compose.runtime:runtime-livedata")
+    implementation(libs.androidx.exifinterface)
 
-  // Camera
+    // Camera
   val cameraVersion = "1.3.1"
   implementation("androidx.camera:camera-lifecycle:$cameraVersion")
   implementation("androidx.camera:camera-camera2:$cameraVersion")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,6 +156,13 @@ dependencies {
   implementation("androidx.compose.runtime:runtime-rxjava2")
   implementation("androidx.compose.runtime:runtime-livedata")
 
+  // Camera
+  val cameraVersion = "1.3.1"
+  implementation("androidx.camera:camera-lifecycle:$cameraVersion")
+  implementation("androidx.camera:camera-camera2:$cameraVersion")
+  implementation("androidx.camera:camera-view:$cameraVersion")
+  implementation("androidx.camera:camera-core:$cameraVersion")
+
   // Testing compose
   androidTestImplementation("androidx.compose.ui:ui-test-junit4")
   debugImplementation("androidx.compose.ui:ui-tooling")
@@ -246,6 +253,10 @@ dependencies {
   // --------------- JUnit ---------------
   testImplementation("junit:junit:4.13.2")
   androidTestImplementation("androidx.test.ext:junit:1.1.5")
+
+  // --------------- Appcompat ---------------
+  implementation("androidx.appcompat:appcompat:1.5.1")
+
 }
 
 configurations.all {

--- a/app/src/androidTest/java/com/example/triptracker/map/AddSpotCameraTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/AddSpotCameraTest.kt
@@ -40,7 +40,8 @@ class AddSpotCameraTest {
           outputDirectory = file,
           executor = cameraExecutor,
           onCaptureClosedSuccess = {},
-          onCaptureClosedError = {})
+          onCaptureClosedError = {},
+          context = appContext)
     }
 
     // Check if the camera is displayed
@@ -60,7 +61,8 @@ class AddSpotCameraTest {
           outputDirectory = file,
           executor = cameraExecutor,
           onCaptureClosedSuccess = {},
-          onCaptureClosedError = {})
+          onCaptureClosedError = {},
+          context = appContext)
     }
 
     // Check if the camera is displayed

--- a/app/src/androidTest/java/com/example/triptracker/map/AddSpotCameraTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/AddSpotCameraTest.kt
@@ -1,0 +1,71 @@
+package com.example.triptracker.map
+
+import android.content.Context
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.GrantPermissionRule
+import com.example.triptracker.view.map.TakePicture
+import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddSpotCameraTest {
+  private val appContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule
+  val permissionRule: GrantPermissionRule =
+      GrantPermissionRule.grant(android.Manifest.permission.CAMERA)
+
+  @Before fun setUp() {}
+
+  @Test
+  fun everythingDisplayed() {
+    composeTestRule.setContent {
+      val file = File("/storage/emulated/0/Download/TripTracker/")
+      file.mkdirs()
+
+      // Create the executor for the camera
+      val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+      TakePicture(
+          outputDirectory = file,
+          executor = cameraExecutor,
+          onCaptureClosedSuccess = {},
+          onCaptureClosedError = {})
+    }
+
+    // Check if the camera is displayed
+    composeTestRule.onNodeWithTag("CameraView").assertExists()
+  }
+
+  @Test
+  fun takePictureTest() {
+    composeTestRule.setContent {
+      val file = File("/storage/emulated/0/Download/TripTracker/")
+      file.mkdirs()
+
+      // Create the executor for the camera
+      val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+      TakePicture(
+          outputDirectory = file,
+          executor = cameraExecutor,
+          onCaptureClosedSuccess = {},
+          onCaptureClosedError = {})
+    }
+
+    // Check if the camera is displayed
+    composeTestRule.onNodeWithTag("CameraView").assertExists()
+    composeTestRule.onNodeWithTag("TakePictureButton").assertExists()
+    composeTestRule.onNodeWithTag("TakePictureButton").performClick()
+  }
+}

--- a/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
@@ -2,6 +2,7 @@ package com.example.triptracker.map
 
 import android.app.Activity
 import android.app.Instrumentation
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.runtime.getValue
@@ -13,6 +14,7 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.isInternal
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
 import com.example.triptracker.screens.AddSpotScreen
 import com.example.triptracker.view.map.AddSpot
 import com.example.triptracker.viewmodel.RecordViewModel
@@ -28,6 +30,7 @@ import org.junit.runner.RunWith
 class AddSpotTest {
 
   @get:Rule val composeTestRule = createComposeRule()
+  private val appContext: Context = InstrumentationRegistry.getInstrumentation().targetContext
 
   @Before
   fun setUp() {
@@ -35,7 +38,7 @@ class AddSpotTest {
       AddSpot(
           recordViewModel = RecordViewModel(),
           latLng = LatLng(46.519879, 6.560632),
-      )
+          context = appContext)
     }
   }
 

--- a/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/map/AddSpotTest.kt
@@ -85,27 +85,26 @@ class AddSpotTest {
     Intents.release()
   }
 
-  /*
-    @Test
-    fun dropDownTestOk() {
-      ComposeScreen.onComposeScreen<AddSpotScreen>(composeTestRule) {
-        locationRow { assertIsDisplayed() }
-        locationText {
-          assertIsDisplayed()
+  //    @Test
+  //    fun dropDownTestOk() {
+  //      ComposeScreen.onComposeScreen<AddSpotScreen>(composeTestRule) {
+  //        locationRow { assertIsDisplayed() }
+  //        locationText {
+  //          assertIsDisplayed()
+  //
+  //          performTextClearance()
+  //
+  //          performTextInput("ecole polytechnique federale")
+  //          composeTestRule.onNodeWithTag("LocationDropDown").performClick()
+  //        }
+  //        runBlocking { delay(2000) }
+  //        locationText {
+  //          assertIsDisplayed()
+  //          assertTextContains("École Polytechnique Fédérale de Lausanne", substring = true)
+  //        }
+  //      }
+  //    }
 
-          performTextClearance()
-
-          performTextInput("ecole polytechnique federale")
-          composeTestRule.onNodeWithTag("LocationDropDown").performClick()
-        }
-        runBlocking { delay(2000) }
-        locationText {
-          assertIsDisplayed()
-          assertTextContains("École Polytechnique Fédérale de Lausanne", substring = true)
-        }
-      }
-    }
-  */
   @Test
   fun dropDownTestNotOk() {
     ComposeScreen.onComposeScreen<AddSpotScreen>(composeTestRule) {
@@ -165,5 +164,24 @@ class AddSpotTest {
         performClick()
       }
     }
+  }
+
+  @Test
+  fun dismissWindowPopUpOk() {
+    ComposeScreen.onComposeScreen<AddSpotScreen>(composeTestRule) {
+      saveButton {
+        performScrollTo()
+        assertIsDisplayed()
+        performClick()
+      }
+
+      composeTestRule.onNodeWithTag("AlertDialog").assertExists()
+    }
+  }
+
+  @Test
+  fun cameraDisplayed() {
+    composeTestRule.onNodeWithTag("Camera").assertExists()
+    composeTestRule.onNodeWithTag("Camera").performClick()
   }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/AddSpotScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/AddSpotScreen.kt
@@ -19,6 +19,6 @@ class AddSpotScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val descriptionText: KNode = description.child { hasTestTag("DescriptionText") }
   val pictures: KNode = child { hasTestTag("SpotPictures") }
   val saveButton: KNode = child { hasTestTag("SaveButton") }
-
+  val alertWindow: KNode = child { hasTestTag("AlertDialog") }
   val editPicture: KNode = child { hasTestTag("EditPicture") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -142,6 +142,35 @@ class HomeTest {
   }
 
   @Test
+  fun clickingOnProfilePictureOpensPreview() {
+    every { mockItineraryRepository.getAllItineraries() } returns mockItineraries
+    every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.filteredItineraryList } returns MutableLiveData(null)
+    every { mockNav.getTopLevelDestinations()[1] } returns
+        TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps")
+    every { mockProfile.userProfile.value } returns mockUsers[0]
+
+    // Setting up the test composition
+    composeTestRule.setContent {
+      HomeScreen(
+          navigation = mockNav, homeViewModel = mockViewModel, test = true, profile = mockProfile)
+    }
+    ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) {
+      profilePic {
+        assertIsDisplayed()
+        performClick()
+      }
+
+      profilePicScreen { assertIsDisplayed() }
+
+      profilePicClose {
+        assertIsDisplayed()
+        performClick()
+      }
+    }
+  }
+
+  @Test
   fun testSearchBarDisplaysComponentsCorrectly() {
     every { mockItineraryRepository.getAllItineraries() } returns mockItineraries
     every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)

--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeViewScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeViewScreen.kt
@@ -13,4 +13,6 @@ class HomeViewScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val itinerarySearch: KNode = searchBar.child { hasSetTextAction() }
   val itinerary: KNode = child { hasTestTag("Itinerary") }
   val profilePic: KNode = child { hasTestTag("ProfilePic") }
+  val profilePicScreen: KNode = child { hasTestTag("ProfilePicBig") }
+  val profilePicClose: KNode = child { hasTestTag("CloseButton") }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-feature android:name="android.hardware.camera.any" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.example.triptracker.MainActivity.Companion.applicationContext
 import com.example.triptracker.authentication.GoogleAuthenticator
 import com.example.triptracker.model.profile.MutableUserProfile
 import com.example.triptracker.model.profile.ProvideUserProfile
@@ -36,6 +35,7 @@ import com.example.triptracker.view.profile.UserProfileOverview
 import com.example.triptracker.view.profile.UserProfileSettings
 import com.example.triptracker.view.profile.UserView
 import com.example.triptracker.view.theme.TripTrackerTheme
+import com.example.triptracker.viewmodel.LaunchCameraPermissionRequest
 import com.example.triptracker.viewmodel.UserProfileViewModel
 
 class MainActivity : ComponentActivity() {
@@ -84,6 +84,7 @@ class MainActivity : ComponentActivity() {
             val context: Context = applicationContext()
 
             LaunchPermissionRequest(context)
+            LaunchCameraPermissionRequest(context)
 
             // List of destinations for in app navigation
             NavHost(

--- a/app/src/main/java/com/example/triptracker/MainActivity.kt
+++ b/app/src/main/java/com/example/triptracker/MainActivity.kt
@@ -18,6 +18,7 @@ import com.example.triptracker.authentication.GoogleAuthenticator
 import com.example.triptracker.model.profile.MutableUserProfile
 import com.example.triptracker.model.profile.ProvideUserProfile
 import com.example.triptracker.navigation.LaunchPermissionRequest
+import com.example.triptracker.view.LaunchCameraPermissionRequest
 import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.OfflineScreen
@@ -35,7 +36,6 @@ import com.example.triptracker.view.profile.UserProfileOverview
 import com.example.triptracker.view.profile.UserProfileSettings
 import com.example.triptracker.view.profile.UserView
 import com.example.triptracker.view.theme.TripTrackerTheme
-import com.example.triptracker.viewmodel.LaunchCameraPermissionRequest
 import com.example.triptracker.viewmodel.UserProfileViewModel
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/example/triptracker/view/CameraPermissions.kt
+++ b/app/src/main/java/com/example/triptracker/view/CameraPermissions.kt
@@ -1,4 +1,4 @@
-package com.example.triptracker.viewmodel
+package com.example.triptracker.view
 
 import android.Manifest
 import android.content.Context

--- a/app/src/main/java/com/example/triptracker/view/LoginScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/LoginScreen.kt
@@ -160,10 +160,9 @@ fun Login(
 ) {
   Column(
       modifier = Modifier.fillMaxSize().padding(15.dp).testTag("LoginScreen"),
-      verticalArrangement = Arrangement.Top,
+      verticalArrangement = Arrangement.Center,
       horizontalAlignment = Alignment.CenterHorizontally,
   ) {
-    Spacer(modifier = Modifier.height(152.dp))
     Image(
         modifier = Modifier.width(189.dp).height(189.dp),
         painter = painterResource(id = R.drawable.logo_no_background),
@@ -181,7 +180,6 @@ fun Login(
                 fontWeight = FontWeight(400),
                 textAlign = TextAlign.Center,
             ))
-    Spacer(modifier = Modifier.height(120.dp))
     Button(
         onClick = {
           val signInIntent = authenticator.createSignInIntent(context)

--- a/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowBackIosNew
 import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -24,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
@@ -76,25 +79,49 @@ fun DisplayItinerary(
   val paddingAround = 15.dp
   // The size of the user's avatar/profile picture
   val avatarSize = 25.dp
-  // Boolean to check if the user profile is ready to display
-  var readyToDisplay by remember { mutableStateOf(false) }
   // The user profile fetched from the database for each path
   var dbProfile by remember { mutableStateOf(UserProfile("")) }
   // The current user profile of the user using the app
   val ambientProfile = AmbientUserProfile.current
+  // Boolean to check if the profile picture should be displayed
+  var showProfilePicture by remember { mutableStateOf(false) }
 
   userProfileViewModel.getUserProfile(itinerary.userMail) {
     if (it != null) {
       dbProfile = it
-      readyToDisplay = true
     }
   }
 
-  when (true) {
-    false -> {
-      Log.d("UserProfile", "User profile is null")
+  when (showProfilePicture) {
+    true -> {
+      Box(
+          modifier =
+              Modifier.fillMaxWidth()
+                  .padding(paddingAround)
+                  .height(boxHeight)
+                  .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))) {
+
+            // Close button
+            IconButton(
+                modifier = Modifier.padding(10.dp).testTag("CloseButton"),
+                onClick = { showProfilePicture = false }) {
+                  Icon(
+                      imageVector = Icons.Outlined.ArrowBackIosNew,
+                      contentDescription = "back",
+                      tint = md_theme_light_onPrimary)
+                }
+
+            AsyncImage(
+                model = dbProfile.profileImageUrl,
+                contentDescription = "User Avatar",
+                modifier =
+                    Modifier.align(Alignment.Center)
+                        .padding(15.dp)
+                        .clip(CircleShape)
+                        .testTag("ProfilePicBig"))
+          }
     }
-    else -> {
+    false -> {
       Box(
           modifier =
               Modifier.fillMaxWidth()
@@ -119,7 +146,7 @@ fun DisplayItinerary(
                               Modifier.size(avatarSize)
                                   .clip(CircleShape)
                                   .testTag("ProfilePic")
-                                  .clickable { /* TODO bring user to profile page */})
+                                  .clickable { showProfilePicture = true })
 
                       Spacer(modifier = Modifier.width(15.dp))
                       Text(

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -1,6 +1,7 @@
 package com.example.triptracker.view.map
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.activity.compose.ManagedActivityResultLauncher
@@ -99,7 +100,12 @@ enum class AddSpotStatus {
  * @param recordViewModel: RecordViewModel
  * @param latLng: LatLng at where the spot is going to be added
  */
-fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> Unit = {}) {
+fun AddSpot(
+    recordViewModel: RecordViewModel,
+    latLng: LatLng,
+    context: Context,
+    onDismiss: () -> Unit = {}
+) {
 
   // Variables to store the state of the add spot box
   var boxDisplayed by remember { mutableStateOf(AddSpotStatus.DISPLAY_FORM) }
@@ -133,6 +139,7 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
       TakePicture(
           outputDirectory = file,
           executor = cameraExecutor,
+          context = context,
           onCaptureClosedSuccess = { boxDisplayed = AddSpotStatus.DISPLAY_FORM },
           onCaptureClosedError = { boxDisplayed = AddSpotStatus.DISPLAY_FORM })
     }
@@ -620,6 +627,6 @@ fun InsertPictures(
 @Preview
 @Composable
 fun AddSpotPreview() {
-  AddSpot(RecordViewModel(), LatLng(46.519053, 6.568287))
+  //  AddSpot(RecordViewModel(), LatLng(46.519053, 6.568287))
   //    AddSpot(RecordViewModel(), LatLng(46.519879, 6.560632))
 }

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -86,6 +86,7 @@ import java.io.File
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
+/** AddSpotStatus is an enum class that represents the different states of the AddSpot box */
 enum class AddSpotStatus {
   DISPLAY_FORM,
   DISPLAY_CAMERA,
@@ -147,6 +148,10 @@ fun AddSpot(
   }
 }
 
+/**
+ * FillAddSpot is a composable function that allows the user to fill the information of the spot
+ * that is going to be added to the path.
+ */
 @Composable
 fun FillAddSpot(
     latLng: LatLng,

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -62,6 +63,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -187,9 +189,10 @@ fun FillAddSpot(
               .testTag("AddSpotScreen")) {
         Column(modifier = Modifier.matchParentSize().verticalScroll(rememberScrollState())) {
           Row(
-              modifier = Modifier.fillMaxWidth(),
+              modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
               horizontalArrangement = Arrangement.SpaceBetween,
               verticalAlignment = Alignment.CenterVertically) {
+                Spacer(modifier = Modifier.weight(1f))
                 // Title
                 Text(
                     text = "Add Spot",
@@ -197,10 +200,12 @@ fun FillAddSpot(
                     fontFamily = FontFamily(Font(R.font.montserrat_regular)),
                     fontWeight = FontWeight.Bold,
                     fontSize = 30.sp,
-                    modifier = Modifier.padding(start = 130.dp).testTag("SpotTitle"))
+                    modifier = Modifier.padding(start = 16.dp, end = 8.dp).testTag("SpotTitle"))
+
+                Spacer(modifier = Modifier.weight(0.7f))
                 // Close button
                 IconButton(
-                    modifier = Modifier.padding(10.dp).testTag("CloseButton"),
+                    modifier = Modifier.testTag("CloseButton"),
                     onClick = { alertIsDisplayed = true }) {
                       Icon(
                           imageVector = Icons.Outlined.Close,
@@ -346,7 +351,10 @@ fun FillAddSpot(
                 // Button to launch the camera
                 IconButton(
                     onClick = { onCameraLaunch() },
-                    modifier = Modifier.align(Alignment.CenterVertically).padding(10.dp)) {
+                    modifier =
+                        Modifier.align(Alignment.CenterVertically)
+                            .padding(10.dp)
+                            .testTag("Camera")) {
                       Icon(
                           modifier = Modifier.size(50.dp),
                           imageVector = Icons.Outlined.Camera,
@@ -362,6 +370,7 @@ fun FillAddSpot(
           when (alertIsDisplayed) {
             true -> {
               AlertDialog(
+                  modifier = Modifier.testTag("AlertDialog"),
                   icon = { Icons.Filled.LocationOn },
                   title = { Text(text = "Path incomplete or don't save this spot") },
                   text = {
@@ -554,6 +563,7 @@ fun InsertPictures(
                         fontFamily = FontFamily(Font(R.font.montserrat_regular)),
                         fontWeight = FontWeight.Normal,
                         fontSize = 20.sp,
+                        textAlign = TextAlign.Center,
                     )
                   }
             }

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -28,6 +29,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.outlined.AddPhotoAlternate
+import androidx.compose.material.icons.outlined.Camera
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.icons.outlined.Edit
@@ -118,8 +120,12 @@ fun AddSpot(recordViewModel: RecordViewModel, latLng: LatLng, onDismiss: () -> U
           onCameraLaunch = { boxDisplayed = AddSpotStatus.DISPLAY_CAMERA })
     }
     AddSpotStatus.DISPLAY_CAMERA -> {
+
+      // Create the directory where the pictures will be saved temporary
       val file = File("/storage/emulated/0/Download/TripTracker/")
       file.mkdirs()
+
+      // Create the executor for the camera
       val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
       TakePicture(
@@ -337,6 +343,16 @@ fun FillAddSpot(
           Row(
               modifier = Modifier.fillMaxWidth().height(150.dp).testTag("SpotPictures"),
               horizontalArrangement = Arrangement.Center) {
+                // Button to launch the camera
+                IconButton(
+                    onClick = { onCameraLaunch() },
+                    modifier = Modifier.align(Alignment.CenterVertically).padding(10.dp)) {
+                      Icon(
+                          modifier = Modifier.size(50.dp),
+                          imageVector = Icons.Outlined.Camera,
+                          contentDescription = "Add Picture",
+                          tint = md_theme_orange)
+                    }
                 InsertPictures(
                     pickMultipleMedia = pickMultipleMedia,
                     selectedPictures,
@@ -379,13 +395,6 @@ fun FillAddSpot(
               modifier = Modifier.fillMaxWidth().fillMaxHeight().testTag("SaveButton"),
               horizontalArrangement = Arrangement.Center,
               verticalAlignment = Alignment.Top) {
-                IconButton(onClick = { onCameraLaunch() }) {
-                  Icon(
-                      imageVector = Icons.Outlined.AddPhotoAlternate,
-                      contentDescription = "Add Picture",
-                      tint = md_theme_orange)
-                }
-
                 FilledTonalButton(
                     onClick = {
                       if ((location.isEmpty() && recordViewModel.namePOI.value.isEmpty()) ||

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
@@ -139,7 +140,8 @@ fun CameraView(
               .padding(top = 80.dp, start = 15.dp, end = 15.dp, bottom = 20.dp)
               .border(1.dp, md_theme_light_black, shape = RoundedCornerShape(35.dp))
               .clip(RoundedCornerShape(35.dp))
-              .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))) {
+              .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))
+              .testTag("CameraView")) {
         AndroidView(
             { previewView },
         ) { view ->
@@ -150,7 +152,11 @@ fun CameraView(
         }
 
         IconButton(
-            modifier = Modifier.padding(bottom = 20.dp).align(Alignment.BottomCenter).size(60.dp),
+            modifier =
+                Modifier.padding(bottom = 20.dp)
+                    .align(Alignment.BottomCenter)
+                    .size(60.dp)
+                    .testTag("TakePictureButton"),
             onClick = {
               takePhoto(
                   context = context,

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -1,0 +1,238 @@
+package com.example.triptracker.view.map
+
+import android.content.ContentValues
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.icu.text.SimpleDateFormat
+import android.net.Uri
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Camera
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.content.ContextCompat
+import coil.compose.rememberAsyncImagePainter
+import com.example.triptracker.view.theme.md_theme_light_surfaceTint
+import java.io.File
+import java.util.Locale
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+@androidx.compose.ui.tooling.preview.Preview
+@Composable
+fun LaunchCamera() {
+  // Temporary path to store the picture
+  val file = File("/storage/emulated/0/Download/TripTracker/")
+  file.mkdirs()
+
+  // Executor to handle the camera operations
+  val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+  TakePicture(
+      outputDirectory = file,
+      executor = cameraExecutor,
+  )
+}
+
+@Composable
+fun TakePicture(
+    outputDirectory: File,
+    executor: Executor,
+) {
+  var shouldShowCamera by remember { mutableStateOf(false) }
+  var photoUri by remember { mutableStateOf<Uri?>(null) }
+
+  when (shouldShowCamera) {
+    true -> {
+      CameraView(
+          outputDirectory = outputDirectory,
+          executor = executor,
+          onImageCaptured = {
+            photoUri = it
+            shouldShowCamera = false
+            Log.d("TakePicture", "Photo uri: $photoUri")
+          },
+          onError = {
+            Log.e("TakePicture", "Error taking picture", it)
+            shouldShowCamera = false
+          })
+    }
+    false -> {
+      Box {
+        IconButton(
+            onClick = { shouldShowCamera = true },
+            content = {
+              Icon(
+                  imageVector = Icons.Outlined.Camera,
+                  contentDescription = "Take picture",
+                  tint = md_theme_light_surfaceTint,
+                  modifier =
+                      Modifier.size(200.dp)
+                          .padding(1.dp)
+                          .border(1.dp, md_theme_light_surfaceTint, CircleShape))
+            })
+        if (photoUri != null) {
+          Image(
+              painter = rememberAsyncImagePainter(photoUri),
+              contentDescription = null,
+              modifier = Modifier.fillMaxSize())
+        }
+      }
+    }
+  }
+}
+
+@Composable
+fun CameraView(
+    outputDirectory: File,
+    executor: Executor,
+    onImageCaptured: (Uri) -> Unit,
+    onError: (ImageCaptureException) -> Unit
+) {
+  val lensFacing = CameraSelector.LENS_FACING_BACK
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+
+  val preview = Preview.Builder().build()
+  val previewView = remember { PreviewView(context) }
+  val imageCapture: ImageCapture = remember { ImageCapture.Builder().build() }
+  val cameraSelector = CameraSelector.Builder().requireLensFacing(lensFacing).build()
+
+  LaunchedEffect(lensFacing) {
+    val cameraProvider = context.getCameraProvider()
+    cameraProvider.unbindAll()
+    cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, imageCapture)
+
+    preview.setSurfaceProvider(previewView.surfaceProvider)
+  }
+
+  Box(contentAlignment = Alignment.BottomCenter, modifier = Modifier.fillMaxSize()) {
+    AndroidView({ previewView }, modifier = Modifier.fillMaxSize())
+
+    IconButton(
+        modifier = Modifier.padding(bottom = 20.dp),
+        onClick = {
+          takePhoto(
+              context = context,
+              imageCapture = imageCapture,
+              outputDirectory = outputDirectory,
+              executor = executor,
+              onImageCaptured = onImageCaptured,
+              onError = onError)
+        },
+        content = {
+          Icon(
+              imageVector = Icons.Outlined.Camera,
+              contentDescription = "Take picture",
+              tint = md_theme_light_surfaceTint,
+              modifier =
+                  Modifier.size(200.dp)
+                      .padding(1.dp)
+                      .border(1.dp, md_theme_light_surfaceTint, CircleShape))
+        })
+  }
+}
+
+private fun takePhoto(
+    context: Context,
+    imageCapture: ImageCapture,
+    outputDirectory: File,
+    executor: Executor,
+    onImageCaptured: (Uri) -> Unit,
+    onError: (ImageCaptureException) -> Unit
+) {
+
+  val photoFile =
+      File(
+          outputDirectory,
+          SimpleDateFormat("yyyy-MM-dd-HH-mm-ss-SSS", Locale.FRANCE)
+              .format(System.currentTimeMillis()) + ".jpg")
+
+  val outputOptions = ImageCapture.OutputFileOptions.Builder(photoFile).build()
+
+  imageCapture.takePicture(
+      outputOptions,
+      executor,
+      object : ImageCapture.OnImageSavedCallback {
+        override fun onError(exception: ImageCaptureException) {
+          onError(exception)
+        }
+
+        override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
+
+          val savedBitmap = BitmapFactory.decodeFile(photoFile.absolutePath)
+
+          // Save the image to the gallery
+          saveImageToGallery(photoFile = photoFile, bitmap = savedBitmap, context = context) {
+              savedUri ->
+            onImageCaptured(savedUri)
+          }
+
+          val savedUri = Uri.fromFile(photoFile)
+          onImageCaptured(savedUri)
+        }
+      })
+}
+
+private fun saveImageToGallery(
+    photoFile: File,
+    bitmap: Bitmap,
+    context: Context,
+    onImageSaved: (Uri) -> Unit
+) {
+  val resolver = context.contentResolver
+
+  val contentValues =
+      ContentValues().apply {
+        put(MediaStore.MediaColumns.DISPLAY_NAME, photoFile.name)
+        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+      }
+
+  val imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
+
+  imageUri?.let { uri ->
+    resolver.openOutputStream(uri)?.use { outputStream ->
+      bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+      onImageSaved(uri)
+    }
+  }
+}
+
+private suspend fun Context.getCameraProvider(): ProcessCameraProvider =
+    suspendCoroutine { continuation ->
+      ProcessCameraProvider.getInstance(this).also { cameraProvider ->
+        cameraProvider.addListener(
+            { continuation.resume(cameraProvider.get()) }, ContextCompat.getMainExecutor(this))
+      }
+    }

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -4,25 +4,31 @@ import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
 import android.icu.text.SimpleDateFormat
+import android.media.ExifInterface
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
 import android.util.Log
+import android.view.ViewGroup
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
-import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Camera
 import androidx.compose.material.icons.outlined.Camera
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -34,42 +40,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
-import coil.compose.rememberAsyncImagePainter
-import com.example.triptracker.view.theme.md_theme_light_surfaceTint
+import com.example.triptracker.view.theme.md_theme_dark_black
+import com.example.triptracker.view.theme.md_theme_light_black
 import java.io.File
 import java.util.Locale
 import java.util.concurrent.Executor
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
-
-@androidx.compose.ui.tooling.preview.Preview
-@Composable
-fun LaunchCamera() {
-  // Temporary path to store the picture
-  val file = File("/storage/emulated/0/Download/TripTracker/")
-  file.mkdirs()
-
-  // Executor to handle the camera operations
-  val cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
-  TakePicture(
-      outputDirectory = file,
-      executor = cameraExecutor,
-  )
-}
 
 @Composable
 fun TakePicture(
     outputDirectory: File,
     executor: Executor,
+    onCaptureClosedSuccess: () -> Unit,
+    onCaptureClosedError: () -> Unit
 ) {
-  var shouldShowCamera by remember { mutableStateOf(false) }
+  var shouldShowCamera by remember { mutableStateOf(true) }
   var photoUri by remember { mutableStateOf<Uri?>(null) }
 
   when (shouldShowCamera) {
@@ -80,35 +73,16 @@ fun TakePicture(
           onImageCaptured = {
             photoUri = it
             shouldShowCamera = false
+            onCaptureClosedSuccess()
             Log.d("TakePicture", "Photo uri: $photoUri")
           },
           onError = {
             Log.e("TakePicture", "Error taking picture", it)
             shouldShowCamera = false
+            onCaptureClosedError()
           })
     }
-    false -> {
-      Box {
-        IconButton(
-            onClick = { shouldShowCamera = true },
-            content = {
-              Icon(
-                  imageVector = Icons.Outlined.Camera,
-                  contentDescription = "Take picture",
-                  tint = md_theme_light_surfaceTint,
-                  modifier =
-                      Modifier.size(200.dp)
-                          .padding(1.dp)
-                          .border(1.dp, md_theme_light_surfaceTint, CircleShape))
-            })
-        if (photoUri != null) {
-          Image(
-              painter = rememberAsyncImagePainter(photoUri),
-              contentDescription = null,
-              modifier = Modifier.fillMaxSize())
-        }
-      }
-    }
+    false -> {}
   }
 }
 
@@ -127,40 +101,58 @@ fun CameraView(
   val previewView = remember { PreviewView(context) }
   val imageCapture: ImageCapture = remember { ImageCapture.Builder().build() }
   val cameraSelector = CameraSelector.Builder().requireLensFacing(lensFacing).build()
+  val configuration = LocalConfiguration.current
+  val orientation = configuration.orientation
+  Log.d("LALALLALAALAL", "Orientation: $orientation")
 
   LaunchedEffect(lensFacing) {
     val cameraProvider = context.getCameraProvider()
     cameraProvider.unbindAll()
     cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, imageCapture)
-
     preview.setSurfaceProvider(previewView.surfaceProvider)
   }
 
-  Box(contentAlignment = Alignment.BottomCenter, modifier = Modifier.fillMaxSize()) {
-    AndroidView({ previewView }, modifier = Modifier.fillMaxSize())
+  Box(
+      contentAlignment = Alignment.Center,
+      modifier =
+          Modifier.fillMaxWidth()
+              .fillMaxHeight(0.85f)
+              .padding(top = 80.dp, start = 15.dp, end = 15.dp, bottom = 20.dp)
+              .border(1.dp, md_theme_light_black, shape = RoundedCornerShape(35.dp))
+              .clip(RoundedCornerShape(35.dp))
+              .background(color = md_theme_light_black, shape = RoundedCornerShape(35.dp))) {
+        AndroidView(
+            { previewView },
+        ) { view ->
+          view.layoutParams =
+              ViewGroup.LayoutParams(
+                  ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+          view.clipToOutline = true
+        }
 
-    IconButton(
-        modifier = Modifier.padding(bottom = 20.dp),
-        onClick = {
-          takePhoto(
-              context = context,
-              imageCapture = imageCapture,
-              outputDirectory = outputDirectory,
-              executor = executor,
-              onImageCaptured = onImageCaptured,
-              onError = onError)
-        },
-        content = {
+        IconButton(
+            modifier = Modifier.padding(bottom = 20.dp).align(Alignment.BottomCenter).size(60.dp),
+            onClick = {
+              takePhoto(
+                  context = context,
+                  imageCapture = imageCapture,
+                  outputDirectory = outputDirectory,
+                  executor = executor,
+                  onImageCaptured = onImageCaptured,
+                  onError = onError,
+                  orientation = orientation)
+            },
+        ) {
           Icon(
-              imageVector = Icons.Outlined.Camera,
+              imageVector = Icons.Default.Camera,
               contentDescription = "Take picture",
-              tint = md_theme_light_surfaceTint,
+              tint = md_theme_dark_black,
               modifier =
-                  Modifier.size(200.dp)
+                  Modifier.size(500.dp)
                       .padding(1.dp)
-                      .border(1.dp, md_theme_light_surfaceTint, CircleShape))
-        })
-  }
+                      .border(1.dp, md_theme_dark_black, CircleShape))
+        }
+      }
 }
 
 private fun takePhoto(
@@ -168,6 +160,7 @@ private fun takePhoto(
     imageCapture: ImageCapture,
     outputDirectory: File,
     executor: Executor,
+    orientation: Int,
     onImageCaptured: (Uri) -> Unit,
     onError: (ImageCaptureException) -> Unit
 ) {
@@ -193,10 +186,13 @@ private fun takePhoto(
           val savedBitmap = BitmapFactory.decodeFile(photoFile.absolutePath)
 
           // Save the image to the gallery
-          saveImageToGallery(photoFile = photoFile, bitmap = savedBitmap, context = context) {
-              savedUri ->
-            onImageCaptured(savedUri)
-          }
+          saveImageToGallery(
+              photoFile = photoFile,
+              bitmap = savedBitmap,
+              context = context,
+              orientation = orientation) { savedUri ->
+                onImageCaptured(savedUri)
+              }
 
           val savedUri = Uri.fromFile(photoFile)
           onImageCaptured(savedUri)
@@ -204,10 +200,29 @@ private fun takePhoto(
       })
 }
 
+private fun adjustBitmapOrientation(filePath: String, bitmap: Bitmap): Bitmap {
+  val ei = ExifInterface(filePath)
+  val orientation =
+      ei.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+  return when (orientation) {
+    ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(bitmap, 90f)
+    ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(bitmap, 180f)
+    ExifInterface.ORIENTATION_ROTATE_270 -> rotateImage(bitmap, 270f)
+    else -> bitmap
+  }
+}
+
+private fun rotateImage(source: Bitmap, angle: Float): Bitmap {
+  val matrix = Matrix()
+  matrix.postRotate(angle)
+  return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
+}
+
 private fun saveImageToGallery(
     photoFile: File,
     bitmap: Bitmap,
     context: Context,
+    orientation: Int,
     onImageSaved: (Uri) -> Unit
 ) {
   val resolver = context.contentResolver
@@ -217,13 +232,15 @@ private fun saveImageToGallery(
         put(MediaStore.MediaColumns.DISPLAY_NAME, photoFile.name)
         put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
         put(MediaStore.MediaColumns.RELATIVE_PATH, Environment.DIRECTORY_PICTURES)
+        put(MediaStore.MediaColumns.ORIENTATION, orientation)
       }
 
   val imageUri = resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
 
   imageUri?.let { uri ->
     resolver.openOutputStream(uri)?.use { outputStream ->
-      bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+      val adjustedBitmap = adjustBitmapOrientation(photoFile.absolutePath, bitmap)
+      adjustedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
       onImageSaved(uri)
     }
   }

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import com.example.triptracker.view.AllowCameraPermission
+import com.example.triptracker.view.checkForCameraPermission
 import com.example.triptracker.view.theme.md_theme_dark_black
 import com.example.triptracker.view.theme.md_theme_light_black
 import java.io.File
@@ -70,10 +72,11 @@ import kotlin.coroutines.suspendCoroutine
 fun TakePicture(
     outputDirectory: File,
     executor: Executor,
+    context: Context,
     onCaptureClosedSuccess: () -> Unit,
     onCaptureClosedError: () -> Unit
 ) {
-  var shouldShowCamera by remember { mutableStateOf(true) }
+  var shouldShowCamera by remember { mutableStateOf(checkForCameraPermission(context)) }
   var photoUri by remember { mutableStateOf<Uri?>(null) }
 
   when (shouldShowCamera) {
@@ -93,7 +96,13 @@ fun TakePicture(
             onCaptureClosedError()
           })
     }
-    false -> {}
+    false -> {
+      if (!checkForCameraPermission(context)) {
+        AllowCameraPermission(
+            onPermissionGranted = { shouldShowCamera = true },
+            onPermissionDenied = { shouldShowCamera = false })
+      }
+    }
   }
 }
 

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Camera
-import androidx.compose.material.icons.outlined.Camera
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -54,6 +54,17 @@ import java.util.concurrent.Executor
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
+/**
+ * Composable that displays the camera view and allows the user to take a picture and saves it to
+ * the gallery.
+ *
+ * @param outputDirectory The directory where the picture will be saved.
+ * @param executor The executor that will be used to take the picture.
+ * @param onCaptureClosedSuccess Callback that will be called when the user closes the camera after
+ *   taking a picture.
+ * @param onCaptureClosedError Callback that will be called when an error occurs while taking a
+ *   picture.
+ */
 @Composable
 fun TakePicture(
     outputDirectory: File,
@@ -85,6 +96,16 @@ fun TakePicture(
   }
 }
 
+/**
+ * Composable that displays the camera view and allows the user to take a picture and saves it to
+ * the gallery.
+ *
+ * @param outputDirectory The directory where the picture will be saved.
+ * @param executor The executor that will be used to take the picture.
+ * @param onImageCaptured Callback that will be called when the picture is taken and gives the link
+ *   to the saved picture.
+ * @param onError Callback that will be called when an error occurs while taking a picture.
+ */
 @Composable
 fun CameraView(
     outputDirectory: File,
@@ -102,7 +123,6 @@ fun CameraView(
   val cameraSelector = CameraSelector.Builder().requireLensFacing(lensFacing).build()
   val configuration = LocalConfiguration.current
   val orientation = configuration.orientation
-  Log.d("LALALLALAALAL", "Orientation: $orientation")
 
   LaunchedEffect(lensFacing) {
     val cameraProvider = context.getCameraProvider()
@@ -154,6 +174,18 @@ fun CameraView(
       }
 }
 
+/**
+ * Function that takes a picture and saves it to the gallery.
+ *
+ * @param context The context of the application.
+ * @param imageCapture The image capture object that will be used to take the picture.
+ * @param outputDirectory The directory where the picture will be saved.
+ * @param executor The executor that will be used to take the picture.
+ * @param orientation The orientation of the device.
+ * @param onImageCaptured Callback that will be called when the picture is taken and gives the link
+ *   to the saved picture.
+ * @param onError Callback that will be called when an error occurs while taking a picture.
+ */
 private fun takePhoto(
     context: Context,
     imageCapture: ImageCapture,
@@ -199,6 +231,13 @@ private fun takePhoto(
       })
 }
 
+/**
+ * Function that adjusts the orientation of the bitmap.
+ *
+ * @param filePath The path of the file.
+ * @param bitmap The bitmap that will be adjusted.
+ * @return The adjusted bitmap.
+ */
 private fun adjustBitmapOrientation(filePath: String, bitmap: Bitmap): Bitmap {
   val ei = ExifInterface(filePath)
   val orientation =
@@ -211,12 +250,28 @@ private fun adjustBitmapOrientation(filePath: String, bitmap: Bitmap): Bitmap {
   }
 }
 
+/**
+ * Function that rotates the image.
+ *
+ * @param source The source bitmap.
+ * @param angle The angle of rotation.
+ * @return The rotated bitmap.
+ */
 private fun rotateImage(source: Bitmap, angle: Float): Bitmap {
   val matrix = Matrix()
   matrix.postRotate(angle)
   return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
 }
 
+/**
+ * Function that saves the image to the gallery.
+ *
+ * @param photoFile The file where the image will be saved.
+ * @param bitmap The bitmap that will be saved.
+ * @param context The context of the application.
+ * @param orientation The orientation of the device.
+ * @param onImageSaved Callback that will be called when the image is saved.
+ */
 private fun saveImageToGallery(
     photoFile: File,
     bitmap: Bitmap,
@@ -245,6 +300,11 @@ private fun saveImageToGallery(
   }
 }
 
+/**
+ * Function that gets the camera provider.
+ *
+ * @return The camera provider.
+ */
 private suspend fun Context.getCameraProvider(): ProcessCameraProvider =
     suspendCoroutine { continuation ->
       ProcessCameraProvider.getInstance(this).also { cameraProvider ->

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -589,6 +589,7 @@ fun StartWindow(viewModel: RecordViewModel, context: Context) {
       AddSpot(
           latLng = viewModel.latLongList.last(),
           recordViewModel = viewModel,
+          context = context,
           onDismiss = { viewModel.addSpotClicked.value = false })
     }
     false -> {}

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -318,17 +318,16 @@ fun Map(
 
       // Button to center on device location
       Row(
-          modifier = Modifier.align(Alignment.BottomCenter),
+          modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 20.dp),
           horizontalArrangement = Arrangement.SpaceBetween) {
+            Spacer(modifier = Modifier.weight(0.1f))
             if (ui.myLocationButtonEnabled && properties.isMyLocationEnabled) {
-              Box(modifier = Modifier.padding(horizontal = 0.dp, vertical = 60.dp)) {
-                DisplayCenterLocationButton(
-                    coroutineScope = coroutineScope,
-                    deviceLocation = deviceLocation,
-                    cameraPositionState = cameraPositionState) { /* DO NOTHING*/}
-              }
+              DisplayCenterLocationButton(
+                  coroutineScope = coroutineScope,
+                  deviceLocation = deviceLocation,
+                  cameraPositionState = cameraPositionState) { /* DO NOTHING*/}
             }
-
+            Spacer(modifier = Modifier.weight(0.5f))
             // Button to start/stop recording
             FilledTonalButton(
                 onClick = {
@@ -340,9 +339,8 @@ fun Map(
                   }
                 },
                 modifier =
-                    Modifier.padding(50.dp)
-                        .fillMaxWidth(0.6f)
-                        .fillMaxHeight(0.1f)
+                    Modifier.fillMaxWidth(0.4f)
+                        .fillMaxHeight(0.08f)
                         .align(Alignment.CenterVertically),
                 colors =
                     ButtonDefaults.filledTonalButtonColors(
@@ -355,7 +353,7 @@ fun Map(
                   fontWeight = FontWeight.SemiBold,
                   color = md_theme_light_onPrimary)
             }
-            Spacer(modifier = Modifier.width(50.dp))
+            Spacer(modifier = Modifier.weight(1f))
           }
     }
 

--- a/app/src/main/java/com/example/triptracker/viewmodel/CameraPermissions.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/CameraPermissions.kt
@@ -17,11 +17,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.core.app.ActivityCompat
 
+/**
+ * Check if the camera permission is granted
+ *
+ * @param context the context of the activity
+ */
 fun checkForCameraPermission(context: Context): Boolean {
   return ActivityCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
       android.content.pm.PackageManager.PERMISSION_GRANTED
 }
 
+/**
+ * Request the camera permission
+ *
+ * @param context the context of the activity
+ */
 @Composable
 fun LaunchCameraPermissionRequest(context: Context) {
   var hasCameraPermission by remember { mutableStateOf(checkForCameraPermission(context)) }
@@ -41,6 +51,12 @@ fun LaunchCameraPermissionRequest(context: Context) {
   }
 }
 
+/**
+ * Display an alert dialog to ask for camera permission
+ *
+ * @param onPermissionGranted the function to call when the permission is granted
+ * @param onPermissionDenied the function to call when the permission is denied
+ */
 @Composable
 fun AllowCameraPermission(onPermissionGranted: () -> Unit, onPermissionDenied: () -> Unit) {
 

--- a/app/src/main/java/com/example/triptracker/viewmodel/CameraPermissions.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/CameraPermissions.kt
@@ -1,0 +1,104 @@
+package com.example.triptracker.viewmodel
+
+import android.Manifest
+import android.content.Context
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.core.app.ActivityCompat
+
+fun checkForCameraPermission(context: Context): Boolean {
+  return ActivityCompat.checkSelfPermission(context, Manifest.permission.CAMERA) ==
+      android.content.pm.PackageManager.PERMISSION_GRANTED
+}
+
+@Composable
+fun LaunchCameraPermissionRequest(context: Context) {
+  var hasCameraPermission by remember { mutableStateOf(checkForCameraPermission(context)) }
+
+  if (hasCameraPermission) {
+    Log.d("Permission", "Camera Permission Granted")
+  } else {
+    AllowCameraPermission(
+        onPermissionGranted = {
+          hasCameraPermission = true
+          Log.d("Permission", "Camera Permission Granted")
+        },
+        onPermissionDenied = {
+          hasCameraPermission = false
+          Log.d("Permission", "Camera Permission NOT Granted")
+        })
+  }
+}
+
+@Composable
+fun AllowCameraPermission(onPermissionGranted: () -> Unit, onPermissionDenied: () -> Unit) {
+
+  val openAlertDialog = remember { mutableStateOf(true) }
+
+  val cameraPermissionLauncher =
+      rememberLauncherForActivityResult(
+          contract = ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+            var isGranted = true
+            permissions.entries.forEach {
+              if (!it.value) {
+                isGranted = false
+                return@forEach
+              }
+            }
+
+            if (isGranted) {
+              onPermissionGranted()
+            } else {
+              onPermissionDenied()
+            }
+          }
+
+  when {
+    openAlertDialog.value -> {
+      AlertDialog(
+          icon = { Icons.Filled.CameraAlt },
+          title = { Text(text = "TripTracker Needs Camera Permissions") },
+          text = {
+            Text(
+                text =
+                    "In order to allow TripTracker to work in an optimal fashion, please allow Camera permission. This will allow you to take pictures for the spots when a path is recorded.")
+          },
+          onDismissRequest = {
+            onPermissionDenied()
+            openAlertDialog.value = false
+          },
+          confirmButton = {
+            TextButton(
+                onClick = {
+                  cameraPermissionLauncher.launch(
+                      arrayOf(
+                          Manifest.permission.CAMERA,
+                      ))
+                  openAlertDialog.value = false
+                }) {
+                  Text("Allow")
+                }
+          },
+          dismissButton = {
+            TextButton(
+                onClick = {
+                  onPermissionDenied()
+                  openAlertDialog.value = false
+                }) {
+                  Text("Don't Allow")
+                }
+          })
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,9 @@ composeBom = "2024.02.02"
 kaspresso = "1.5.5"
 robolectric = "4.11.1"
 sonar = "4.4.1.3373"
+cameraCore = "1.3.3"
+cameraLifecycle = "1.3.3"
+cameraView = "1.3.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -33,4 +36,7 @@ kaspresso = { group = "com.kaspersky.android-components", name = "kaspresso", ve
 kaspresso-compose = { group = "com.kaspersky.android-components", name = "kaspresso-compose-support", version.ref = "kaspresso" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+androidx-camera-core = { group = "androidx.camera", name = "camera-core", version.ref = "cameraCore" }
+androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraLifecycle" }
+androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraView" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ sonar = "4.4.1.3373"
 cameraCore = "1.3.3"
 cameraLifecycle = "1.3.3"
 cameraView = "1.3.3"
+exifinterface = "1.3.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -39,4 +40,5 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 androidx-camera-core = { group = "androidx.camera", name = "camera-core", version.ref = "cameraCore" }
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraLifecycle" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraView" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 


### PR DESCRIPTION
This PR will bring some changes to the UI : 
- It will allow to click on the profile picture of other users in the app in order to display it in a more convenient format.
<image src = https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/79469048/7a2a93fc-3538-4e70-b870-573c380f6ab5 width = 300>

- AddSpot allows to take picture directly in the app and store them in the gallery. The user is then able to pick the taken pictures with the photopicker
<image src = https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/79469048/9c563658-762a-4618-8d0a-5b06c5e84887 width =300>

- It will ask for Camera permissions on launch of the app so that pictures can be taken in the AddSpot screen and will also reask permissions when the camera is launched even it not accepted.

- Test for all the classes are added in order to achieve 80% code coverage
