### PR TITLE
Friend views test

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
@@ -13,7 +13,18 @@ class UserProfileFollowersScreen(semanticsProvider: SemanticsNodeInteractionsPro
   // Structural elements of the UI
   val followersTitle: KNode = child { hasTestTag("FollowersTitle") }
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
-  val followersList: KNode = child { hasTestTag("FollowersList") }
-  val removeButton: KNode = child { hasTestTag("RemoveButton") }
-  val followerProfile: KNode = child { hasTestTag("FriendProfile") }
+    val followersList: KNode = child { hasTestTag("FollowersList") }
+
+    // FriendListView
+    val friendsList: KNode = child { hasTestTag("FriendsList") }
+    val friendProfile: KNode = child { hasTestTag("FriendProfile") }
+
+    // RemoveFriendButton
+    val removeButton: KNode = child { hasTestTag("RemoveButton") }
+
+    // FriendSearchBar
+    val searchBar: KNode = child { hasTestTag("SearchBar") }
+    val searchBarText: KNode = child { hasTestTag("SearchBarText") }
+    val searchIcon: KNode = child { hasTestTag("SearchIcon") }
+    val clearButton: KNode = child { hasTestTag("ClearButton") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowersScreen.kt
@@ -13,18 +13,18 @@ class UserProfileFollowersScreen(semanticsProvider: SemanticsNodeInteractionsPro
   // Structural elements of the UI
   val followersTitle: KNode = child { hasTestTag("FollowersTitle") }
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
-    val followersList: KNode = child { hasTestTag("FollowersList") }
+  val followersList: KNode = child { hasTestTag("FollowersList") }
 
-    // FriendListView
-    val friendsList: KNode = child { hasTestTag("FriendsList") }
-    val friendProfile: KNode = child { hasTestTag("FriendProfile") }
+  // FriendListView
+  val friendsList: KNode = child { hasTestTag("FriendsList") }
+  val friendProfile: KNode = child { hasTestTag("FriendProfile") }
 
-    // RemoveFriendButton
-    val removeButton: KNode = child { hasTestTag("RemoveButton") }
+  // RemoveFriendButton
+  val removeButton: KNode = child { hasTestTag("RemoveButton") }
 
-    // FriendSearchBar
-    val searchBar: KNode = child { hasTestTag("SearchBar") }
-    val searchBarText: KNode = child { hasTestTag("SearchBarText") }
-    val searchIcon: KNode = child { hasTestTag("SearchIcon") }
-    val clearButton: KNode = child { hasTestTag("ClearButton") }
+  // FriendSearchBar
+  val searchBar: KNode = child { hasTestTag("SearchBar") }
+  val searchBarText: KNode = child { hasTestTag("SearchBarText") }
+  val searchIcon: KNode = child { hasTestTag("SearchIcon") }
+  val clearButton: KNode = child { hasTestTag("ClearButton") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
@@ -15,10 +15,10 @@ class UserProfileFollowingScreen(semanticsProvider: SemanticsNodeInteractionsPro
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
   val followingList: KNode = child { hasTestTag("FollowingList") }
 
-    // FriendListView
-    val friendsList: KNode = child { hasTestTag("FriendsList") }
-    val friendProfile: KNode = child { hasTestTag("FriendProfile") }
+  // FriendListView
+  val friendsList: KNode = child { hasTestTag("FriendsList") }
+  val friendProfile: KNode = child { hasTestTag("FriendProfile") }
 
-    // RemoveFriendButton
-    val removeButton: KNode = child { hasTestTag("RemoveButton") }
-    }
+  // RemoveFriendButton
+  val removeButton: KNode = child { hasTestTag("RemoveButton") }
+}

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFollowingScreen.kt
@@ -13,7 +13,12 @@ class UserProfileFollowingScreen(semanticsProvider: SemanticsNodeInteractionsPro
   // Structural elements of the UI
   val followingTitle: KNode = child { hasTestTag("FollowingTitle") }
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
-  val removeButton: KNode = child { hasTestTag("RemoveButton") }
   val followingList: KNode = child { hasTestTag("FollowingList") }
-  val followingProfile: KNode = child { hasTestTag("FriendProfile") }
-}
+
+    // FriendListView
+    val friendsList: KNode = child { hasTestTag("FriendsList") }
+    val friendProfile: KNode = child { hasTestTag("FriendProfile") }
+
+    // RemoveFriendButton
+    val removeButton: KNode = child { hasTestTag("RemoveButton") }
+    }

--- a/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFriendsScreen.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/userProfile/UserProfileFriendsScreen.kt
@@ -11,9 +11,13 @@ class UserProfileFriendsScreen(semanticsProvider: SemanticsNodeInteractionsProvi
         viewBuilderAction = { hasTestTag("FriendsFinderScreen") }) {
 
   // Structural elements of the UI
+
+  // UserProfileFriends
   val friendsTitle: KNode = child { hasTestTag("FriendsFinderTitle") }
   val goBackButton: KNode = child { hasTestTag("GoBackButton") }
+
+  // FriendListView
   val friendsList: KNode = child { hasTestTag("FriendsList") }
-  val removeButton: KNode = child { hasTestTag("RemoveButton") }
   val friendProfile: KNode = child { hasTestTag("FriendProfile") }
+  val notDisplayingProfile: KNode = child { hasTestTag("NotDisplayingProfile") }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowersTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowersTest.kt
@@ -76,12 +76,8 @@ class UserProfileFollowersTest {
         assertIsDisplayed()
         assertTextEquals("Followers")
       }
-        followersList {
-            assertIsDisplayed()
-        }
-      goBackButton {
-        assertIsDisplayed()
-      }
+      followersList { assertIsDisplayed() }
+      goBackButton { assertIsDisplayed() }
     }
   }
 
@@ -134,9 +130,9 @@ class UserProfileFollowersTest {
     // Setting up the test composition
     composeTestRule.setContent {
       UserProfileFollowers(
-        navigation = mockNav,
-        profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
-        userProfileViewModel = mockViewModel)
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel)
     }
     ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
       searchBar {

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowersTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowersTest.kt
@@ -1,128 +1,149 @@
-// package com.example.triptracker.userProfile
-//
-// import androidx.compose.ui.test.junit4.createComposeRule
-// import androidx.lifecycle.MutableLiveData
-// import androidx.test.ext.junit.runners.AndroidJUnit4
-// import com.example.triptracker.model.profile.UserProfile
-// import com.example.triptracker.model.repository.UserProfileRepository
-// import com.example.triptracker.screens.userProfile.UserProfileFollowersScreen
-// import com.example.triptracker.view.Navigation
-// import com.example.triptracker.view.profile.UserProfileFollowers
-// import com.example.triptracker.viewmodel.UserProfileViewModel
-// import io.github.kakaocup.compose.node.element.ComposeScreen
-// import io.mockk.Runs
-// import io.mockk.every
-// import io.mockk.impl.annotations.RelaxedMockK
-// import io.mockk.junit4.MockKRule
-// import io.mockk.just
-// import io.mockk.mockk
-// import org.junit.Before
-// import org.junit.Rule
-// import org.junit.Test
-// import org.junit.runner.RunWith
-//
-// @RunWith(AndroidJUnit4::class)
-// class UserProfileFollowersTest {
-//  @get:Rule val composeTestRule = createComposeRule()
-//
-//  // @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()  // Ensure LiveData
-// executes
-//  // immediately
-//
-//  @get:Rule val mockkRule = MockKRule(this)
-//
-//  @RelaxedMockK private lateinit var mockViewModel: UserProfileViewModel
-//  @RelaxedMockK private lateinit var mockUserProfileRepository: UserProfileRepository
-//  @RelaxedMockK private lateinit var mockNavigation: Navigation
-//
-//  private val mockList = MockUserList()
-//  private val mockUserProfiles = mockList.getUserProfiles()
-//
-//  private lateinit var filteredProfilesLiveData: MutableLiveData<List<UserProfile>>
-//
-//  @Before
-//  fun setUp() { // Mocking necessary components
-//    mockNavigation = mockk(relaxed = true)
-//    mockViewModel = mockk(relaxUnitFun = true)
-//    mockUserProfileRepository = mockk(relaxUnitFun = true)
-//
-//    // Setup the LiveData with initial data or as per test case requirements
-//    filteredProfilesLiveData = MutableLiveData<List<UserProfile>>(mockUserProfiles)
-//
-//    every { mockViewModel.filteredUserProfileList } returns filteredProfilesLiveData
-//  }
-//
-//  @Test
-//  fun componentsAreCorrectlyDisplayed() {
-//    mockViewModel = mockk {
-//      every { getUserProfileList() } returns mockUserProfiles
-//      every { getUserProfile(any(), any()) } coAnswers
-//          {
-//            secondArg<(UserProfile?) -> Unit>().invoke(mockUserProfiles[6])
-//          }
-//      every { setListToFilter(any()) } just Runs
-//      every { mockUserProfileRepository.getAllUserProfiles(any()) } answers {
-//          // Invoke the callback with mock data
-//          val callback = arg<(List<UserProfile>) -> Unit>(0)
-//          callback(mockUserProfiles)
-//        }
-//    }
-//
-//    // Setting up the test composition
-//    composeTestRule.setContent {
-//      UserProfileFollowers(navigation = mockNavigation, userProfileViewModel = mockViewModel)
-//    }
-//    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
-//      // Test the UI elements
-//      followersTitle {
-//        assertIsDisplayed()
-//        assertTextEquals("Followers")
-//      }
-//      //      goBackButton {
-//      //        assertIsDisplayed()
-//      //        assertHasClickAction()
-//      //      }
-//      //      followersList { assertIsDisplayed() }
-//      //      followerProfile { assertIsDisplayed() }
-//    }
-//  }
-//
-//  //  @Test
-//  //  fun removeButtonWorks() {
-//  //    every { mockUserProfileRepository.getAllUserProfiles() } returns mockUserProfiles
-//  //    every { mockViewModel.getUserProfileList() } returns mockUserProfiles
-//  //    // Setting up the test composition
-//  //    composeTestRule.setContent {
-//  //      UserProfileFollowers(navigation = mockNav, viewModel = mockViewModel)
-//  //    }
-//  //    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
-//  //      removeButton {
-//  //        assertIsDisplayed()
-//  //        assertTextEquals("Remove")
-//  //        assertHasClickAction()
-//  //        performClick()
-//  //        assertTextEquals("Undo")
-//  //        performClick()
-//  //        assertTextEquals("Remove")
-//  //      }
-//  //    }
-//  //  }
-//  //
-//  //  @Test
-//  //  fun backButtonWorks() {
-//  //    every { mockUserProfileRepository.getAllUserProfiles() } returns mockUserProfiles
-//  //    every { mockViewModel.getUserProfileList() } returns mockUserProfiles
-//  //    // Setting up the test composition
-//  //    composeTestRule.setContent {
-//  //      UserProfileFollowers(navigation = mockNav, viewModel = mockViewModel)
-//  //    }
-//  //    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
-//  //      // Test the UI elements
-//  //      goBackButton {
-//  //        assertIsDisplayed()
-//  //        assertHasClickAction()
-//  //        performClick()
-//  //      }
-//  //    }
-//  //  }
-// }
+package com.example.triptracker.userProfile
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.triptracker.model.profile.MutableUserProfile
+import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.model.repository.UserProfileRepository
+import com.example.triptracker.screens.userProfile.UserProfileFollowersScreen
+import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.profile.UserProfileFollowers
+import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.just
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UserProfileFollowersTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  @RelaxedMockK lateinit var mockNav: Navigation
+  @RelaxedMockK private lateinit var mockViewModel: UserProfileViewModel
+  @RelaxedMockK private lateinit var mockUserProfileRepository: UserProfileRepository
+
+  private val mockList = MockUserList()
+  private val mockUserProfiles = mockList.getUserProfiles()
+
+  @Before
+  fun setUp() { // Mocking necessary components
+    mockNav = mockk(relaxed = true)
+    mockUserProfileRepository = mockk(relaxed = true)
+    mockViewModel = mockk(relaxed = true)
+
+    mockViewModel = mockk {
+      every { getUserProfileList() } returns mockUserProfiles
+      every { getUserProfile(any(), any()) } answers
+          {
+            secondArg<(UserProfile?) -> Unit>().invoke(mockUserProfiles[0])
+          }
+      every { userProfileList.value } returns mockUserProfiles
+      every { userProfileList } returns MutableLiveData(mockUserProfiles)
+      every { setListToFilter(any()) } just Runs
+      every { filteredUserProfileList.value } returns mockUserProfiles
+      every { filteredUserProfileList } returns MutableLiveData(mockUserProfiles)
+      every { setSearchQuery(any()) } just Runs
+      every { searchQuery } returns MutableLiveData("") // Default empty search query
+      every { addFollower(any(), any()) } just Runs
+      every { removeFollower(any(), any()) } just Runs
+    }
+  }
+
+  @Test
+  fun componentsAreCorrectlyDisplayed() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowers(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel)
+    }
+
+    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
+      // Test the UI elements
+      followersTitle {
+        assertIsDisplayed()
+        assertTextEquals("Followers")
+      }
+        followersList {
+            assertIsDisplayed()
+        }
+      goBackButton {
+        assertIsDisplayed()
+      }
+    }
+  }
+
+  @Test
+  fun removeFollowersWorks() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowers(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel)
+    }
+
+    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
+      friendProfile {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+      removeButton {
+        assertIsDisplayed()
+        assertTextEquals("Undo")
+        assertHasClickAction()
+        performClick()
+      }
+    }
+  }
+
+  @Test
+  fun backButtonWorks() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowers(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel)
+    }
+
+    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
+      // Test the UI elements
+      goBackButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        performClick()
+      }
+    }
+  }
+
+  @Test
+  fun searchBarWorks() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowers(
+        navigation = mockNav,
+        profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+        userProfileViewModel = mockViewModel)
+    }
+    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
+      searchBar {
+        assertIsDisplayed()
+        performClick()
+        performTextInput("test")
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowingTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowingTest.kt
@@ -7,8 +7,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.model.profile.MutableUserProfile
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.model.repository.UserProfileRepository
+import com.example.triptracker.screens.userProfile.UserProfileFollowersScreen
 import com.example.triptracker.screens.userProfile.UserProfileFollowingScreen
 import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.profile.UserProfileFollowers
 import com.example.triptracker.view.profile.UserProfileFollowing
 import com.example.triptracker.viewmodel.UserProfileViewModel
 import io.github.kakaocup.compose.node.element.ComposeScreen
@@ -45,9 +47,9 @@ class UserProfileFollowingTest {
     mockViewModel = mockk {
       every { getUserProfileList() } returns mockUserProfiles
       every { getUserProfile(any(), any()) } answers
-              {
-                secondArg<(UserProfile?) -> Unit>().invoke(mockUserProfiles[0])
-              }
+          {
+            secondArg<(UserProfile?) -> Unit>().invoke(mockUserProfiles[0])
+          }
       every { userProfileList.value } returns mockUserProfiles
       every { userProfileList } returns MutableLiveData(mockUserProfiles)
       every { setListToFilter(any()) } just Runs
@@ -127,6 +129,24 @@ class UserProfileFollowingTest {
         assertIsDisplayed()
         assertHasClickAction()
         performClick()
+      }
+    }
+  }
+
+  @Test
+  fun searchBarWorks() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowers(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel)
+    }
+    ComposeScreen.onComposeScreen<UserProfileFollowersScreen>(composeTestRule) {
+      searchBar {
+        assertIsDisplayed()
+        performClick()
+        performTextInput("test")
       }
     }
   }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowingTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFollowingTest.kt
@@ -1,114 +1,133 @@
-// package com.example.triptracker.userProfile
-//
-// import androidx.compose.material.icons.Icons
-// import androidx.compose.material.icons.outlined.Home
-// import androidx.compose.ui.test.junit4.createComposeRule
-// import androidx.test.ext.junit.runners.AndroidJUnit4
-// import com.example.triptracker.model.repository.UserProfileRepository
-// import com.example.triptracker.screens.userProfile.UserProfileFollowingScreen
-// import com.example.triptracker.view.Navigation
-// import com.example.triptracker.view.Route
-// import com.example.triptracker.view.TopLevelDestination
-// import com.example.triptracker.view.profile.UserProfileFollowing
-// import com.example.triptracker.viewmodel.UserProfileViewModel
-// import io.github.kakaocup.compose.node.element.ComposeScreen
-// import io.mockk.every
-// import io.mockk.impl.annotations.RelaxedMockK
-// import io.mockk.junit4.MockKRule
-// import io.mockk.mockk
-// import org.junit.Before
-// import org.junit.Rule
-// import org.junit.Test
-// import org.junit.runner.RunWith
-//
-// @RunWith(AndroidJUnit4::class)
-// class UserProfileFollowingTest {
-//  @get:Rule val composeTestRule = createComposeRule()
-//
-//  @get:Rule val mockkRule = MockKRule(this)
-//
-//  @RelaxedMockK lateinit var mockNav: Navigation
-//  @RelaxedMockK private lateinit var mockViewModel: UserProfileViewModel
-//  @RelaxedMockK private lateinit var mockUserProfileRepository: UserProfileRepository
-//
-//  private val mockList = MockUserList()
-//  private val mockUserProfiles = mockList.getUserProfiles()
-//
-//  @Before
-//  fun setUp() { // Mocking necessary components
-//    mockNav = mockk(relaxed = true)
-//    mockUserProfileRepository = mockk(relaxed = true)
-//    mockViewModel = mockk(relaxed = true)
-//
-//    // Log.d("ItineraryList", mockViewModel.itineraryList.value.toString())
-//    every { mockNav.getTopLevelDestinations()[0] } returns
-//        TopLevelDestination(Route.HOME, Icons.Outlined.Home, "Home")
-//  }
-//
-//  @Test
-//  fun componentsAreCorrectlyDisplayed() {
-//    // Have to repeat code to have specific mock data for each test!!
-//    every { mockUserProfileRepository.getAllUserProfiles() } returns mockUserProfiles
-//    every { mockViewModel.getUserProfileList() } returns mockUserProfiles
-//    // Setting up the test composition
-//    composeTestRule.setContent {
-//      UserProfileFollowing(
-//          navigation = mockNav,
-//          userProfileViewModel = mockViewModel,
-//      )
-//    }
-//    ComposeScreen.onComposeScreen<UserProfileFollowingScreen>(composeTestRule) {
-//      // Test the UI elements
-//      followingTitle {
-//        assertIsDisplayed()
-//        assertTextEquals("Following")
-//      }
-//      goBackButton {
-//        assertIsDisplayed()
-//        assertHasClickAction()
-//      }
-//      followingList { assertIsDisplayed() }
-//      followingProfile { assertIsDisplayed() }
-//    }
-//  }
-//
-//  @Test
-//  fun removeButtonWorks() {
-//    // Have to repeat code to have specific mock data for each test!!
-//    every { mockUserProfileRepository.getAllUserProfiles() } returns mockUserProfiles
-//    every { mockViewModel.getUserProfileList() } returns mockUserProfiles
-//    // Setting up the test composition
-//    composeTestRule.setContent {
-//      UserProfileFollowing(navigation = mockNav, userProfileViewModel = mockViewModel)
-//    }
-//    ComposeScreen.onComposeScreen<UserProfileFollowingScreen>(composeTestRule) {
-//      removeButton {
-//        assertIsDisplayed()
-//        assertTextEquals("Following")
-//        assertHasClickAction()
-//        performClick()
-//        assertTextEquals("Follow")
-//        performClick()
-//        assertTextEquals("Following")
-//      }
-//    }
-//  }
-//
-//  @Test
-//  fun backButtonWorks() {
-//    every { mockUserProfileRepository.getAllUserProfiles() } returns mockUserProfiles
-//    every { mockViewModel.getUserProfileList() } returns mockUserProfiles
-//    // Setting up the test composition
-//    composeTestRule.setContent {
-//      UserProfileFollowing(navigation = mockNav, userProfileViewModel = mockViewModel)
-//    }
-//    ComposeScreen.onComposeScreen<UserProfileFollowingScreen>(composeTestRule) {
-//      // Test the UI elements
-//      goBackButton {
-//        assertIsDisplayed()
-//        assertHasClickAction()
-//        performClick()
-//      }
-//    }
-//  }
-// }
+package com.example.triptracker.userProfile
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.MutableLiveData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.triptracker.model.profile.MutableUserProfile
+import com.example.triptracker.model.profile.UserProfile
+import com.example.triptracker.model.repository.UserProfileRepository
+import com.example.triptracker.screens.userProfile.UserProfileFollowingScreen
+import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.profile.UserProfileFollowing
+import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import io.mockk.just
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class UserProfileFollowingTest {
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @get:Rule val mockkRule = MockKRule(this)
+
+  @RelaxedMockK lateinit var mockNav: Navigation
+  @RelaxedMockK private lateinit var mockViewModel: UserProfileViewModel
+  @RelaxedMockK private lateinit var mockUserProfileRepository: UserProfileRepository
+
+  private val mockList = MockUserList()
+  private val mockUserProfiles = mockList.getUserProfiles()
+
+  @Before
+  fun setUp() { // Mocking necessary components
+    mockNav = mockk(relaxed = true)
+    mockUserProfileRepository = mockk(relaxed = true)
+    mockViewModel = mockk(relaxed = true)
+
+    mockViewModel = mockk {
+      every { getUserProfileList() } returns mockUserProfiles
+      every { getUserProfile(any(), any()) } answers
+              {
+                secondArg<(UserProfile?) -> Unit>().invoke(mockUserProfiles[0])
+              }
+      every { userProfileList.value } returns mockUserProfiles
+      every { userProfileList } returns MutableLiveData(mockUserProfiles)
+      every { setListToFilter(any()) } just Runs
+      every { filteredUserProfileList.value } returns mockUserProfiles
+      every { filteredUserProfileList } returns MutableLiveData(mockUserProfiles)
+      every { setSearchQuery(any()) } just Runs
+      every { searchQuery } returns MutableLiveData("") // Default empty search query
+      every { addFollowing(any(), any()) } just Runs
+      every { removeFollowing(any(), any()) } just Runs
+    }
+  }
+
+  @Test
+  fun componentsAreCorrectlyDisplayed() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowing(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel,
+      )
+    }
+    ComposeScreen.onComposeScreen<UserProfileFollowingScreen>(composeTestRule) {
+      // Test the UI elements
+      followingTitle {
+        assertIsDisplayed()
+        assertTextEquals("Following")
+      }
+      followingList { assertIsDisplayed() }
+
+      goBackButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+    }
+  }
+
+  @Test
+  fun removeButtonWorks() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowing(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel,
+      )
+    }
+
+    ComposeScreen.onComposeScreen<UserProfileFollowingScreen>(composeTestRule) {
+      friendProfile {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+      removeButton {
+        assertIsDisplayed()
+        assertTextEquals("Follow")
+        assertHasClickAction()
+        performClick()
+      }
+    }
+  }
+
+  @Test
+  fun backButtonWorks() {
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFollowing(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel,
+      )
+    }
+
+    ComposeScreen.onComposeScreen<UserProfileFollowingScreen>(composeTestRule) {
+      // Test the UI elements
+      goBackButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+        performClick()
+      }
+    }
+  }
+}

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFriendsTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFriendsTest.kt
@@ -1,13 +1,22 @@
 package com.example.triptracker.userProfile
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.lifecycle.MutableLiveData
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.triptracker.model.profile.MutableUserProfile
+import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.model.repository.UserProfileRepository
+import com.example.triptracker.screens.userProfile.UserProfileFriendsScreen
 import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.profile.UserProfileFriends
 import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.github.kakaocup.compose.node.element.ComposeScreen
+import io.mockk.Runs
+import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.just
 import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
@@ -26,26 +35,49 @@ class UserProfileFriendsTest {
 
   private val mockList = MockUserList()
   private val mockUserProfiles = mockList.getUserProfiles()
-  private val liveDataMockUserProfiles = MutableLiveData(mockUserProfiles)
 
   @Before
   fun setUp() { // Mocking necessary components
     mockNav = mockk(relaxed = true)
     mockUserProfileRepository = mockk(relaxed = true)
     mockViewModel = mockk(relaxed = true)
+
+    mockViewModel = mockk {
+      every { getUserProfileList() } returns mockUserProfiles
+      every { getUserProfile(any(), any()) } answers
+          {
+            secondArg<(UserProfile?) -> Unit>().invoke(mockUserProfiles[0])
+          }
+      every { userProfileList.value } returns mockUserProfiles
+      every { userProfileList } returns MutableLiveData(mockUserProfiles)
+      every { setListToFilter(any()) } just Runs
+      every { filteredUserProfileList.value } returns mockUserProfiles
+      every { filteredUserProfileList } returns MutableLiveData(mockUserProfiles)
+      every { searchQuery } returns MutableLiveData("") // Default empty search query
+    }
   }
 
   @Test
   fun componentAreCorrectlyDisplayed() {
-    //    every { mockUserProfileRepository.getAllUserProfiles() } returns mockUserProfiles
-    //    every { mockViewModel.getUserProfileList() } returns liveDataMockUserProfiles.value!!
-    //    // Setting up the test composition
-    //    composeTestRule.setContent {
-    //      UserProfileFriends(
-    //          navigation = mockNav,
-    //          userProfileViewModel = mockViewModel,
-    //      )
-    //    }
-    //    ComposeScreen.onComposeScreen<UserProfileFriendsScreen>(composeTestRule) {}
+
+    // Setting up the test composition
+    composeTestRule.setContent {
+      UserProfileFriends(
+          navigation = mockNav,
+          profile = MutableUserProfile(mutableStateOf(mockUserProfiles[0])),
+          userProfileViewModel = mockViewModel,
+      )
+    }
+    ComposeScreen.onComposeScreen<UserProfileFriendsScreen>(composeTestRule) {
+      friendsTitle { assertIsDisplayed() }
+      friendsList { assertIsDisplayed() }
+      notDisplayingProfile {
+        assertIsDisplayed()
+      }
+      goBackButton {
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
+    }
   }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFriendsTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileFriendsTest.kt
@@ -71,9 +71,7 @@ class UserProfileFriendsTest {
     ComposeScreen.onComposeScreen<UserProfileFriendsScreen>(composeTestRule) {
       friendsTitle { assertIsDisplayed() }
       friendsList { assertIsDisplayed() }
-      notDisplayingProfile {
-        assertIsDisplayed()
-      }
+      notDisplayingProfile { assertIsDisplayed() }
       goBackButton {
         assertIsDisplayed()
         assertHasClickAction()

--- a/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/FriendListView.kt
@@ -75,7 +75,7 @@ fun FriendListView(
   if (friendList.value.isEmpty() ||
       (relationship == Relationship.FRIENDS && viewModel.searchQuery.value == "")) {
     Column(
-        modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+        modifier = Modifier.fillMaxWidth().fillMaxHeight().testTag("NotDisplayingProfile"),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally) {
           Text(
@@ -101,8 +101,7 @@ fun FriendListView(
   } else {
     // Display the list of user's profiles
     LazyColumn(
-        modifier =
-            Modifier.fillMaxWidth().fillMaxHeight().padding(15.dp).testTag("FriendListScreen"),
+        modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(15.dp).testTag("FriendList"),
         verticalArrangement = Arrangement.spacedBy(10.dp)) {
           items(friendList.value) { friend ->
             // we do not prompt the profile of the current user

--- a/app/src/main/java/com/example/triptracker/view/profile/FriendSearchBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/FriendSearchBar.kt
@@ -66,7 +66,7 @@ fun FriendSearchBar(viewModel: UserProfileViewModel, onSearchActivated: (Boolean
             placeholder = {
               Text(
                   "Find Friends",
-                  modifier = Modifier.padding(start = 10.dp).testTag("searchBarText"),
+                  modifier = Modifier.padding(start = 10.dp).testTag("SearchBarText"),
                   textAlign = TextAlign.Center,
                   fontFamily = FontFamily(Font(R.font.montserrat_bold)),
                   fontSize = 21.sp,
@@ -78,6 +78,7 @@ fun FriendSearchBar(viewModel: UserProfileViewModel, onSearchActivated: (Boolean
               Icon(
                   imageVector = Icons.Default.Search,
                   contentDescription = "Search",
+                  modifier = Modifier.testTag("SearchIcon"),
                   tint = if (isActive) Color.DarkGray else Color.Gray)
             },
             trailingIcon = {
@@ -86,7 +87,8 @@ fun FriendSearchBar(viewModel: UserProfileViewModel, onSearchActivated: (Boolean
                     onClick = {
                       searchText = ""
                       viewModel.setSearchQuery("")
-                    }) {
+                    },
+                    modifier = Modifier.testTag("ClearButton")) {
                       Icon(
                           imageVector = Icons.Default.Close,
                           contentDescription = "Clear",
@@ -109,6 +111,6 @@ fun FriendSearchBar(viewModel: UserProfileViewModel, onSearchActivated: (Boolean
                       focusManager.clearFocus()
                       onSearchActivated(false)
                     }),
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp))
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp).testTag("SearchBar"))
       }
 }


### PR DESCRIPTION
**Corresponding issue: #152** 

This PR provides tests for the following views in the User Profile section:
- `UserProfileFollowing` : displays the accounts of people following the authenticated user
- `UserProfileFollower` : displays the accounts of the people followed by the authenticated user
- `UserProfileFriends` : enables the user to look for other people's account and start following them

Those views all relies on the following subviews that get tested as well : 
- `FriendListView` : handles the way of displaying the list of users
- `RemoveFriendButton` : is used to manage the relation with the displayed user 
- `FriendSearchBar` : is used to easily search among the displayed users based on their name, surname or username