### PR TITLE
Save the country and city location when recording a path

### DIFF
--- a/app/src/main/java/com/example/triptracker/model/geocoder/NominatimApi.kt
+++ b/app/src/main/java/com/example/triptracker/model/geocoder/NominatimApi.kt
@@ -150,6 +150,7 @@ class NominatimApi {
    * @param lat : latitude of the location
    * @param lon : longitude of the location
    * @param callback : function to call when the city is decoded
+   * @param withCountry : boolean to indicate if the country should be included in the city
    */
   fun getCity(lat: Float, lon: Float, callback: (String) -> Unit, withCountry: Boolean = false) {
     reverseDecode(lat, lon) { json ->

--- a/app/src/main/java/com/example/triptracker/model/geocoder/NominatimApi.kt
+++ b/app/src/main/java/com/example/triptracker/model/geocoder/NominatimApi.kt
@@ -16,6 +16,7 @@ import org.json.JSONObject
  */
 object LocationStrings {
   const val ADDRESS = "address"
+  const val COUNTRY = "country"
   const val CITY = "city"
   const val VILLAGE = "village"
   const val TOWN = "town"
@@ -150,7 +151,7 @@ class NominatimApi {
    * @param lon : longitude of the location
    * @param callback : function to call when the city is decoded
    */
-  fun getCity(lat: Float, lon: Float, callback: (String) -> Unit) {
+  fun getCity(lat: Float, lon: Float, callback: (String) -> Unit, withCountry: Boolean = false) {
     reverseDecode(lat, lon) { json ->
       if (json.toString() == LocationErrors.ERROR) {
         callback(LocationErrors.UNKNOWN)
@@ -164,21 +165,30 @@ class NominatimApi {
         return@reverseDecode
       }
 
+      val addressJson = address as JSONObject
+
+      // get the country from the address json object
+      val country =
+          if (withCountry && addressJson.has(LocationStrings.COUNTRY)) {
+            addressJson.get(LocationStrings.COUNTRY) as? String ?: LocationErrors.UNKNOWN
+          } else {
+            LocationErrors.UNKNOWN
+          }
+
       // get the city, village or town from the address json object since there are multiple
       // ways to describe a "city"
-      val addressJson = address as JSONObject
-      if (addressJson.has(LocationStrings.CITY)) {
-        val cityName = addressJson.get(LocationStrings.CITY) as? String ?: LocationErrors.UNKNOWN
-        callback(cityName)
-      } else if (addressJson.has(LocationStrings.VILLAGE)) {
-        val village = addressJson.get(LocationStrings.VILLAGE) as? String ?: LocationErrors.UNKNOWN
-        callback(village)
-      } else if (addressJson.has(LocationStrings.TOWN)) {
-        val town = addressJson.get(LocationStrings.TOWN) as? String ?: LocationErrors.UNKNOWN
-        callback(town)
-      } else {
-        callback(LocationErrors.UNKNOWN)
-      }
+      val city =
+          if (addressJson.has(LocationStrings.CITY)) {
+            addressJson.get(LocationStrings.CITY) as? String ?: LocationErrors.UNKNOWN
+          } else if (addressJson.has(LocationStrings.VILLAGE)) {
+            addressJson.get(LocationStrings.VILLAGE) as? String ?: LocationErrors.UNKNOWN
+          } else if (addressJson.has(LocationStrings.TOWN)) {
+            addressJson.get(LocationStrings.TOWN) as? String ?: LocationErrors.UNKNOWN
+          } else {
+            LocationErrors.UNKNOWN
+          }
+
+      callback(if (withCountry && country != LocationErrors.UNKNOWN) "$city, $country" else city)
     }
   }
 

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -507,11 +507,17 @@ fun Map(
                                     // but not
                                     // implemented yet
                                     val meanLocation = meanLocation(viewModel.latLongList.toList())
+                                    var locationName = ""
+                                    viewModel.getCityAndCountry(
+                                        meanLocation.latitude.toFloat(),
+                                        meanLocation.longitude.toFloat()) {
+                                          locationName = it
+                                        }
                                     val location =
                                         Location(
                                             meanLocation.latitude,
                                             meanLocation.longitude,
-                                            "Mean Path Location")
+                                            locationName)
                                     // (default device location)
                                     val flameCount = 0L
                                     val saves = 0L

--- a/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/MapViewModel.kt
@@ -72,7 +72,7 @@ class MapViewModel(
    * @param lon : longitude of the location
    */
   fun reverseDecode(lat: Float, lon: Float, _geocoder: NominatimApi = geocoder) {
-    _geocoder.getCity(lat, lon) { cityName -> cityNameState.value = cityName }
+    _geocoder.getCity(lat, lon, callback = { cityName -> cityNameState.value = cityName })
   }
 
   /** Get all itineraries from the database and update the pathList */

--- a/app/src/main/java/com/example/triptracker/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/RecordViewModel.kt
@@ -219,6 +219,7 @@ class RecordViewModel(
    *
    * @param lat : latitude of the location
    * @param lon : longitude of the location
+   * @param callback : function to call when the city and country names are decoded
    */
   fun getCityAndCountry(lat: Float, lon: Float, callback: (String) -> Unit) {
     geocoder.getCity(lat, lon, callback = callback, true)

--- a/app/src/main/java/com/example/triptracker/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/RecordViewModel.kt
@@ -213,6 +213,17 @@ class RecordViewModel(
     }
   }
 
+  /**
+   * Reverse decodes the location to get the city name. On success update the cityNameState at the
+   * top of the screen
+   *
+   * @param lat : latitude of the location
+   * @param lon : longitude of the location
+   */
+  fun getCityAndCountry(lat: Float, lon: Float, callback: (String) -> Unit) {
+    geocoder.getCity(lat, lon, callback = callback, true)
+  }
+
   /** Gets the point of interest (POI) name at the given LatLng point. */
   fun getPOI(latLng: LatLng) {
     geocoder.getPOI(latLng.latitude.toFloat(), latLng.longitude.toFloat()) { name ->

--- a/app/src/test/java/com/example/triptracker/NominatimGeocoderTest.kt
+++ b/app/src/test/java/com/example/triptracker/NominatimGeocoderTest.kt
@@ -23,9 +23,10 @@ class NominatimGeocoderTest {
   @Test
   fun getCityTest() {
     val geocoder = NominatimApi()
-    geocoder.getCity(46.519053.toFloat(), 6.568287.toFloat()) { city -> assert(city == "Lausanne") }
+    geocoder.getCity(
+        46.519053.toFloat(), 6.568287.toFloat(), callback = { city -> assert(city == "Lausanne") })
 
-    geocoder.getCity(0.0.toFloat(), 0.0.toFloat()) { city -> assert(city == "Unknown") }
+    geocoder.getCity(0.0.toFloat(), 0.0.toFloat(), callback = { city -> assert(city == "Unknown") })
   }
 
   @Test


### PR DESCRIPTION
This PR add the functionality to save the City and the Country when recording a path, which is helpful later when searching paths based on their location.

For demonstration (not kept in the map screen):
<img width="421" alt="CleanShot 2024-05-15 at 19 34 53@2x" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/90ff8970-e9c0-4ebc-8b61-4d51600e6d87">
