### PR TITLE
Profile refinements

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/userProfile/DropDownSelectorTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/DropDownSelectorTest.kt
@@ -20,207 +20,205 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class DropDownSelectorTest: TestCase() {
-    @get:Rule val composeTestRule = createComposeRule()
+class DropDownSelectorTest : TestCase() {
+  @get:Rule val composeTestRule = createComposeRule()
 
-    @Test
-    fun languagesSelectorTest() {
-        // Test the drop down selector
-        composeTestRule.setContent {
-            var selectedLanguages by remember {
-                mutableStateOf(
-                    listOf(
-                        Languages.Dutch.toString(),
-                        Languages.Arabic.toString()
-                    )
-                )
-            }
+  @Test
+  fun languagesSelectorTest() {
+    // Test the drop down selector
+    composeTestRule.setContent {
+      var selectedLanguages by remember {
+        mutableStateOf(listOf(Languages.Dutch.toString(), Languages.Arabic.toString()))
+      }
 
-            DropdownSelector(
-                label = "Languages",
-                options = Languages.entries,
-                selectedOptions = selectedLanguages,
-                onOptionSelected = { selectedLanguages = it },
-                placeholder = "No Languages"
-            )
-        }
-        // we check that the "Language" label is displayed
-        composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Languages")
-        // we check that the selected languages are displayed
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch, Arabic")
-        // we check that the drop down button is displayed and we click on it to open the drop down menu
-        composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
-        // we check that the drop down menu is displayed
-        composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
-        // we check that the drop down menu items are displayed
-        composeTestRule.onNodeWithTag("DropDownMenuItemDutch").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemEnglish").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemFrench").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemGerman").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemItalian").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemJapanese").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemKorean").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemPortuguese").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemRussian").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemSpanish").assertIsDisplayed()
-        // we check that once unselected, the selected language is removed from the drop down text field
-        composeTestRule.onNodeWithTag("DropDownMenuItemArabic").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch")
-        // we check that once selected, the selected language is added to the drop down text field
-        composeTestRule.onNodeWithTag("DropDownMenuItemChinese").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch, Chinese")
+      DropdownSelector(
+          label = "Languages",
+          options = Languages.entries,
+          selectedOptions = selectedLanguages,
+          onOptionSelected = { selectedLanguages = it },
+          placeholder = "No Languages")
     }
+    // we check that the "Language" label is displayed
+    composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Languages")
+    // we check that the selected languages are displayed
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Dutch, Arabic")
+    // we check that the drop down button is displayed and we click on it to open the drop down menu
+    composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
+    // we check that the drop down menu is displayed
+    composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
+    // we check that the drop down menu items are displayed
+    composeTestRule.onNodeWithTag("DropDownMenuItemDutch").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemEnglish").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemFrench").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemGerman").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemItalian").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemJapanese").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemKorean").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemPortuguese").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemRussian").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemSpanish").assertIsDisplayed()
+    // we check that once unselected, the selected language is removed from the drop down text field
+    composeTestRule.onNodeWithTag("DropDownMenuItemArabic").assertIsDisplayed().performClick()
+    composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch")
+    // we check that once selected, the selected language is added to the drop down text field
+    composeTestRule.onNodeWithTag("DropDownMenuItemChinese").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Dutch, Chinese")
+  }
 
-    @Test
-    fun emptyLanguagesSelectorTest() {
-        composeTestRule.setContent {
-            var selectedLanguages by remember {
-                mutableStateOf(
-                    emptyList<String>()
-                )
-            }
+  @Test
+  fun emptyLanguagesSelectorTest() {
+    composeTestRule.setContent {
+      var selectedLanguages by remember { mutableStateOf(emptyList<String>()) }
 
-            DropdownSelector(
-                label = "Languages",
-                options = Languages.entries,
-                selectedOptions = selectedLanguages,
-                onOptionSelected = { selectedLanguages = it },
-                placeholder = "No Languages"
-            )
-        }
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("No Languages")
-
+      DropdownSelector(
+          label = "Languages",
+          options = Languages.entries,
+          selectedOptions = selectedLanguages,
+          onOptionSelected = { selectedLanguages = it },
+          placeholder = "No Languages")
     }
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("No Languages")
+  }
 
-    @Test
-    fun travelStyleSelectorTest() {
-        // Test the drop down selector
-        composeTestRule.setContent {
-            var selectedTravelStyle by remember {
-                mutableStateOf(
-                    listOf(
-                        TravelStyle.Adventurous.toString(),
-                        TravelStyle.Backpacking.toString()
-                    )
-                )
-            }
+  @Test
+  fun travelStyleSelectorTest() {
+    // Test the drop down selector
+    composeTestRule.setContent {
+      var selectedTravelStyle by remember {
+        mutableStateOf(
+            listOf(TravelStyle.Adventurous.toString(), TravelStyle.Backpacking.toString()))
+      }
 
-            DropdownSelector(
-                label = "Travel Style",
-                options = TravelStyle.entries,
-                selectedOptions = selectedTravelStyle,
-                onOptionSelected = { selectedTravelStyle = it },
-                placeholder = "No Travel Style"
-            )
-        }
-        // we check that the "Travel Style" label is displayed
-        composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Travel Style")
-        // we check that the selected languages are displayed
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Adventurous, Backpacking")
-        // we check that the drop down button is displayed and we click on it to open the drop down menu
-        composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
-        // we check that the drop down menu is displayed
-        composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
-        // we check that the drop down menu items are displayed
-        composeTestRule.onNodeWithTag("DropDownMenuItemBackpacking").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemCultural").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemGroup").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemLuxury").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemRelaxing").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemRoadTrip").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemSolo").assertIsDisplayed()
-        // we check that once unselected, the selected travel style is removed from the drop down text field
-        composeTestRule.onNodeWithTag("DropDownMenuItemAdventurous").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Backpacking")
-        // we check that once selected, the selected travel style is added to the drop down text field
-        composeTestRule.onNodeWithTag("DropDownMenuItemCamping").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Backpacking, Camping")
+      DropdownSelector(
+          label = "Travel Style",
+          options = TravelStyle.entries,
+          selectedOptions = selectedTravelStyle,
+          onOptionSelected = { selectedTravelStyle = it },
+          placeholder = "No Travel Style")
     }
+    // we check that the "Travel Style" label is displayed
+    composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Travel Style")
+    // we check that the selected languages are displayed
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Adventurous, Backpacking")
+    // we check that the drop down button is displayed and we click on it to open the drop down menu
+    composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
+    // we check that the drop down menu is displayed
+    composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
+    // we check that the drop down menu items are displayed
+    composeTestRule.onNodeWithTag("DropDownMenuItemBackpacking").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemCultural").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemGroup").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemLuxury").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemRelaxing").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemRoadTrip").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemSolo").assertIsDisplayed()
+    // we check that once unselected, the selected travel style is removed from the drop down text
+    // field
+    composeTestRule.onNodeWithTag("DropDownMenuItemAdventurous").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Backpacking")
+    // we check that once selected, the selected travel style is added to the drop down text field
+    composeTestRule.onNodeWithTag("DropDownMenuItemCamping").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Backpacking, Camping")
+  }
 
-    @Test
-    fun emptyTravelStyleSelectorTest() {
-        composeTestRule.setContent {
-            var selectedTravelStyle by remember {
-                mutableStateOf(
-                    emptyList<String>()
-                )
-            }
+  @Test
+  fun emptyTravelStyleSelectorTest() {
+    composeTestRule.setContent {
+      var selectedTravelStyle by remember { mutableStateOf(emptyList<String>()) }
 
-            DropdownSelector(
-                label = "TravelStyle",
-                options = TravelStyle.entries,
-                selectedOptions = selectedTravelStyle,
-                onOptionSelected = { selectedTravelStyle = it },
-                placeholder = "No Travel Style"
-            )
-        }
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("No Travel Style")
-
+      DropdownSelector(
+          label = "TravelStyle",
+          options = TravelStyle.entries,
+          selectedOptions = selectedTravelStyle,
+          onOptionSelected = { selectedTravelStyle = it },
+          placeholder = "No Travel Style")
     }
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("No Travel Style")
+  }
 
-    @Test
-    fun interestsSelectorTest() {
-        // Test the drop down selector
-        composeTestRule.setContent {
-            var selectedInterests by remember {
-                mutableStateOf(
-                    listOf(
-                        Interests.Culture.toString(),
-                        Interests.Cycling.toString()
-                    )
-                )
-            }
+  @Test
+  fun interestsSelectorTest() {
+    // Test the drop down selector
+    composeTestRule.setContent {
+      var selectedInterests by remember {
+        mutableStateOf(listOf(Interests.Culture.toString(), Interests.Cycling.toString()))
+      }
 
-            DropdownSelector(
-                label = "Interests",
-                options = Interests.entries,
-                selectedOptions = selectedInterests,
-                onOptionSelected = { selectedInterests = it },
-                placeholder = "No Interests"
-            )
-        }
-        // we check that the "Interests" label is displayed
-        composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Interests")
-        // we check that the selected languages are displayed
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Culture, Cycling")
-        // we check that the drop down button is displayed and we click on it to open the drop down menu
-        composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
-        // we check that the drop down menu is displayed
-        composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
-        // we check that the drop down menu items are displayed
-        composeTestRule.onNodeWithTag("DropDownMenuItemCycling").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemHiking").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemNature").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemPhotography").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemRunning").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("DropDownMenuItemWalking").assertIsDisplayed()
-        // we check that once unselected, the selected interest is removed from the drop down text field
-        composeTestRule.onNodeWithTag("DropDownMenuItemCulture").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Cycling")
-        // we check that once selected, the selected interest is added to the drop down text field
-        composeTestRule.onNodeWithTag("DropDownMenuItemFood").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Cycling, Food")
+      DropdownSelector(
+          label = "Interests",
+          options = Interests.entries,
+          selectedOptions = selectedInterests,
+          onOptionSelected = { selectedInterests = it },
+          placeholder = "No Interests")
     }
+    // we check that the "Interests" label is displayed
+    composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Interests")
+    // we check that the selected languages are displayed
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Culture, Cycling")
+    // we check that the drop down button is displayed and we click on it to open the drop down menu
+    composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
+    // we check that the drop down menu is displayed
+    composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
+    // we check that the drop down menu items are displayed
+    composeTestRule.onNodeWithTag("DropDownMenuItemCycling").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemHiking").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemNature").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemPhotography").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemRunning").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("DropDownMenuItemWalking").assertIsDisplayed()
+    // we check that once unselected, the selected interest is removed from the drop down text field
+    composeTestRule.onNodeWithTag("DropDownMenuItemCulture").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Cycling")
+    // we check that once selected, the selected interest is added to the drop down text field
+    composeTestRule.onNodeWithTag("DropDownMenuItemFood").assertIsDisplayed().performClick()
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("Cycling, Food")
+  }
 
-    @Test
-    fun emptyInterestsSelectorTest() {
-        composeTestRule.setContent {
-            var selectedInterests by remember {
-                mutableStateOf(
-                    emptyList<String>()
-                )
-            }
+  @Test
+  fun emptyInterestsSelectorTest() {
+    composeTestRule.setContent {
+      var selectedInterests by remember { mutableStateOf(emptyList<String>()) }
 
-            DropdownSelector(
-                label = "Interests",
-                options = Interests.entries,
-                selectedOptions = selectedInterests,
-                onOptionSelected = { selectedInterests = it },
-                placeholder = "No Interests"
-            )
-        }
-        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("No Interests")
-
+      DropdownSelector(
+          label = "Interests",
+          options = Interests.entries,
+          selectedOptions = selectedInterests,
+          onOptionSelected = { selectedInterests = it },
+          placeholder = "No Interests")
     }
-
+    composeTestRule
+        .onNodeWithTag("DropDownTextField")
+        .assertIsDisplayed()
+        .assertTextEquals("No Interests")
+  }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/DropDownSelectorTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/DropDownSelectorTest.kt
@@ -1,0 +1,226 @@
+package com.example.triptracker.userProfile
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.triptracker.view.profile.Interests
+import com.example.triptracker.view.profile.Languages
+import com.example.triptracker.view.profile.TravelStyle
+import com.example.triptracker.view.profile.subviews.DropdownSelector
+import junit.framework.TestCase
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DropDownSelectorTest: TestCase() {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun languagesSelectorTest() {
+        // Test the drop down selector
+        composeTestRule.setContent {
+            var selectedLanguages by remember {
+                mutableStateOf(
+                    listOf(
+                        Languages.Dutch.toString(),
+                        Languages.Arabic.toString()
+                    )
+                )
+            }
+
+            DropdownSelector(
+                label = "Languages",
+                options = Languages.entries,
+                selectedOptions = selectedLanguages,
+                onOptionSelected = { selectedLanguages = it },
+                placeholder = "No Languages"
+            )
+        }
+        // we check that the "Language" label is displayed
+        composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Languages")
+        // we check that the selected languages are displayed
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch, Arabic")
+        // we check that the drop down button is displayed and we click on it to open the drop down menu
+        composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
+        // we check that the drop down menu is displayed
+        composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
+        // we check that the drop down menu items are displayed
+        composeTestRule.onNodeWithTag("DropDownMenuItemDutch").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemEnglish").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemFrench").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemGerman").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemItalian").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemJapanese").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemKorean").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemPortuguese").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemRussian").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemSpanish").assertIsDisplayed()
+        // we check that once unselected, the selected language is removed from the drop down text field
+        composeTestRule.onNodeWithTag("DropDownMenuItemArabic").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch")
+        // we check that once selected, the selected language is added to the drop down text field
+        composeTestRule.onNodeWithTag("DropDownMenuItemChinese").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Dutch, Chinese")
+    }
+
+    @Test
+    fun emptyLanguagesSelectorTest() {
+        composeTestRule.setContent {
+            var selectedLanguages by remember {
+                mutableStateOf(
+                    emptyList<String>()
+                )
+            }
+
+            DropdownSelector(
+                label = "Languages",
+                options = Languages.entries,
+                selectedOptions = selectedLanguages,
+                onOptionSelected = { selectedLanguages = it },
+                placeholder = "No Languages"
+            )
+        }
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("No Languages")
+
+    }
+
+    @Test
+    fun travelStyleSelectorTest() {
+        // Test the drop down selector
+        composeTestRule.setContent {
+            var selectedTravelStyle by remember {
+                mutableStateOf(
+                    listOf(
+                        TravelStyle.Adventurous.toString(),
+                        TravelStyle.Backpacking.toString()
+                    )
+                )
+            }
+
+            DropdownSelector(
+                label = "Travel Style",
+                options = TravelStyle.entries,
+                selectedOptions = selectedTravelStyle,
+                onOptionSelected = { selectedTravelStyle = it },
+                placeholder = "No Travel Style"
+            )
+        }
+        // we check that the "Travel Style" label is displayed
+        composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Travel Style")
+        // we check that the selected languages are displayed
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Adventurous, Backpacking")
+        // we check that the drop down button is displayed and we click on it to open the drop down menu
+        composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
+        // we check that the drop down menu is displayed
+        composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
+        // we check that the drop down menu items are displayed
+        composeTestRule.onNodeWithTag("DropDownMenuItemBackpacking").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemCultural").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemGroup").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemLuxury").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemRelaxing").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemRoadTrip").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemSolo").assertIsDisplayed()
+        // we check that once unselected, the selected travel style is removed from the drop down text field
+        composeTestRule.onNodeWithTag("DropDownMenuItemAdventurous").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Backpacking")
+        // we check that once selected, the selected travel style is added to the drop down text field
+        composeTestRule.onNodeWithTag("DropDownMenuItemCamping").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Backpacking, Camping")
+    }
+
+    @Test
+    fun emptyTravelStyleSelectorTest() {
+        composeTestRule.setContent {
+            var selectedTravelStyle by remember {
+                mutableStateOf(
+                    emptyList<String>()
+                )
+            }
+
+            DropdownSelector(
+                label = "TravelStyle",
+                options = TravelStyle.entries,
+                selectedOptions = selectedTravelStyle,
+                onOptionSelected = { selectedTravelStyle = it },
+                placeholder = "No Travel Style"
+            )
+        }
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("No Travel Style")
+
+    }
+
+    @Test
+    fun interestsSelectorTest() {
+        // Test the drop down selector
+        composeTestRule.setContent {
+            var selectedInterests by remember {
+                mutableStateOf(
+                    listOf(
+                        Interests.Culture.toString(),
+                        Interests.Cycling.toString()
+                    )
+                )
+            }
+
+            DropdownSelector(
+                label = "Interests",
+                options = Interests.entries,
+                selectedOptions = selectedInterests,
+                onOptionSelected = { selectedInterests = it },
+                placeholder = "No Interests"
+            )
+        }
+        // we check that the "Interests" label is displayed
+        composeTestRule.onNodeWithTag("Label").assertIsDisplayed().assertTextEquals("Interests")
+        // we check that the selected languages are displayed
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Culture, Cycling")
+        // we check that the drop down button is displayed and we click on it to open the drop down menu
+        composeTestRule.onNodeWithTag("DropDownButton").assertIsDisplayed().performClick()
+        // we check that the drop down menu is displayed
+        composeTestRule.onNodeWithTag("DropDownMenu").assertIsDisplayed()
+        // we check that the drop down menu items are displayed
+        composeTestRule.onNodeWithTag("DropDownMenuItemCycling").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemHiking").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemNature").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemPhotography").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemRunning").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("DropDownMenuItemWalking").assertIsDisplayed()
+        // we check that once unselected, the selected interest is removed from the drop down text field
+        composeTestRule.onNodeWithTag("DropDownMenuItemCulture").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Cycling")
+        // we check that once selected, the selected interest is added to the drop down text field
+        composeTestRule.onNodeWithTag("DropDownMenuItemFood").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("Cycling, Food")
+    }
+
+    @Test
+    fun emptyInterestsSelectorTest() {
+        composeTestRule.setContent {
+            var selectedInterests by remember {
+                mutableStateOf(
+                    emptyList<String>()
+                )
+            }
+
+            DropdownSelector(
+                label = "Interests",
+                options = Interests.entries,
+                selectedOptions = selectedInterests,
+                onOptionSelected = { selectedInterests = it },
+                placeholder = "No Interests"
+            )
+        }
+        composeTestRule.onNodeWithTag("DropDownTextField").assertIsDisplayed().assertTextEquals("No Interests")
+
+    }
+
+}

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.model.profile.MutableUserProfile
 import com.example.triptracker.model.profile.UserProfile
@@ -167,7 +168,7 @@ class UserProfileEditScreenTest : TestCase() {
     composeTestRule.setContent {
       UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
     }
-    composeTestRule.onNodeWithText("Interests").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Interests").performScrollTo().assertIsDisplayed()
   }
 
   @Test
@@ -175,7 +176,7 @@ class UserProfileEditScreenTest : TestCase() {
     composeTestRule.setContent {
       UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
     }
-    composeTestRule.onNodeWithText("Travel Style").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Travel Style").performScrollTo().assertIsDisplayed()
   }
 
   @Test
@@ -183,6 +184,6 @@ class UserProfileEditScreenTest : TestCase() {
     composeTestRule.setContent {
       UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
     }
-    composeTestRule.onNodeWithText("Languages").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Languages").performScrollTo().assertIsDisplayed()
   }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
@@ -176,7 +176,7 @@ class UserProfileEditScreenTest : TestCase() {
     composeTestRule.setContent {
       UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
     }
-    composeTestRule.onNodeWithText("Travel Style").performScrollTo().assertIsDisplayed()
+    composeTestRule.onNodeWithText("Travel style").performScrollTo().assertIsDisplayed()
   }
 
   @Test

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
@@ -1,4 +1,4 @@
-package com.example.triptracker.screens.userProfile
+package com.example.triptracker.userProfile
 
 import android.net.Uri
 import androidx.activity.compose.ManagedActivityResultLauncher
@@ -161,4 +161,29 @@ class UserProfileEditScreenTest : TestCase() {
     }
     composeTestRule.onNodeWithText("Save").performClick()
   }
+
+  @Test
+  fun interestsTest() {
+    composeTestRule.setContent {
+      UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
+    }
+    composeTestRule.onNodeWithText("Interests").assertIsDisplayed()
+
+  }
+
+  @Test
+  fun travelStyleTest() {
+    composeTestRule.setContent {
+      UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
+    }
+    composeTestRule.onNodeWithText("Travel Style").assertIsDisplayed()
+  }
+
+    @Test
+    fun languagesTest() {
+      composeTestRule.setContent {
+        UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
+      }
+      composeTestRule.onNodeWithText("Languages").assertIsDisplayed()
+    }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileEditScreenTest.kt
@@ -168,7 +168,6 @@ class UserProfileEditScreenTest : TestCase() {
       UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
     }
     composeTestRule.onNodeWithText("Interests").assertIsDisplayed()
-
   }
 
   @Test
@@ -179,11 +178,11 @@ class UserProfileEditScreenTest : TestCase() {
     composeTestRule.onNodeWithText("Travel Style").assertIsDisplayed()
   }
 
-    @Test
-    fun languagesTest() {
-      composeTestRule.setContent {
-        UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
-      }
-      composeTestRule.onNodeWithText("Languages").assertIsDisplayed()
+  @Test
+  fun languagesTest() {
+    composeTestRule.setContent {
+      UserProfileEditScreen(navigation = navigation, profile = MutableUserProfile())
     }
+    composeTestRule.onNodeWithText("Languages").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileTest.kt
@@ -20,7 +20,11 @@ class UserProfileTest {
           profileImageUrl = "stupid-image-url.com",
           following = emptyList(),
           followers = emptyList(),
-          favoritesPaths = emptyList())
+          favoritesPaths = emptyList(),
+          interests = emptyList(),
+          travelStyle = emptyList(),
+          languages = emptyList(),
+      )
 
   private val userProfile2 =
       UserProfile(
@@ -50,6 +54,9 @@ class UserProfileTest {
     assertEquals(emptyList<UserProfile>(), userProfile1.following)
     assertEquals(emptyList<UserProfile>(), userProfile1.followers)
     assertEquals(emptyList<String>(), userProfile1.favoritesPaths)
+    assertEquals(emptyList<String>(), userProfile1.interests)
+    assertEquals(emptyList<String>(), userProfile1.travelStyle)
+    assertEquals(emptyList<String>(), userProfile1.languages)
   }
 
   @Test
@@ -63,6 +70,9 @@ class UserProfileTest {
     assertEquals(emptyList<UserProfile>(), userProfile2.following)
     assertEquals(emptyList<UserProfile>(), userProfile2.followers)
     assertEquals(emptyList<String>(), userProfile2.favoritesPaths)
+    assertEquals(emptyList<String>(), userProfile2.interests)
+    assertEquals(emptyList<String>(), userProfile2.travelStyle)
+    assertEquals(emptyList<String>(), userProfile2.languages)
   }
 
   @Test

--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserViewTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserViewTest.kt
@@ -101,11 +101,6 @@ class UserViewTest {
       }
       languagesList { assertIsDisplayed() }
       followingButton { assertIsDisplayed() }
-      tripsTitle {
-        assertIsDisplayed()
-        assertTextEquals("Trips")
-      }
-      tripsCount { assertIsDisplayed() }
       goBackButton {
         assertIsDisplayed()
         assertHasClickAction()

--- a/app/src/main/java/com/example/triptracker/model/profile/UserProfile.kt
+++ b/app/src/main/java/com/example/triptracker/model/profile/UserProfile.kt
@@ -21,6 +21,9 @@ import androidx.compose.runtime.mutableStateOf
  * @property profilePrivacy : privacy of the user's profile 0 = public and 1 = private
  * @property itineraryPrivacy : privacy of the user's itineraries 0 = public, 1 = friends, 2 =
  *   private
+ * @property interests : list of user's interests. (Defaults: empty list)
+ * @property travelStyle : list of user's travel style. (Defaults: empty list)
+ * @property languages : list of user's spoken languages. (Defaults: empty list)
  */
 data class UserProfile(
     val mail: String,
@@ -34,6 +37,9 @@ data class UserProfile(
     val favoritesPaths: List<String> = emptyList(),
     val profilePrivacy: Int = 0,
     val itineraryPrivacy: Int = 0,
+    val interests: List<String> = emptyList(),
+    val travelStyle: List<String> = emptyList(),
+    val languages: List<String> = emptyList(),
 )
 
 /** This data class represents a mutable user's profile information. */

--- a/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
@@ -116,11 +116,18 @@ open class UserProfileRepository {
     // if favoritesPaths doesn't exist create the fiald in the database
     val favoritesPaths =
         document.data?.get("favoritesPaths") as? List<String> ?: createFavoritesPaths(document.id)
-
     val profilePrivacy = document.getLong("profilePrivacy") ?: createProfilePrivacy(document.id)
-
     val itineraryPrivacy =
         document.getLong("itineraryPrivacy") ?: createItineraryPrivacy(document.id)
+    val interest =
+        document.data?.get("interests") as? List<String>
+            ?: throw IllegalStateException("Interests is missing")
+    val travelStyle =
+        document.data?.get("travelStyle") as? List<String>
+            ?: throw IllegalStateException("Travel style is missing")
+    val languages =
+        document.data?.get("languages") as? List<String>
+            ?: throw IllegalStateException("Languages is missing")
 
     return UserProfile(
         document.id,
@@ -133,7 +140,10 @@ open class UserProfileRepository {
         following,
         favoritesPaths,
         profilePrivacy.toInt(),
-        itineraryPrivacy.toInt())
+        itineraryPrivacy.toInt(),
+        interest,
+        travelStyle,
+        languages)
   }
 
   private fun createFavoritesPaths(id: String): List<String> {
@@ -194,11 +204,18 @@ open class UserProfileRepository {
               ?: throw IllegalStateException("Following is missing")
       val favoritesPaths =
           document.data["favoritesPaths"] as? List<String> ?: createFavoritesPaths(document.id)
-
       val profilePrivacy = document.getLong("profilePrivacy") ?: createProfilePrivacy(document.id)
-
       val itineraryPrivacy =
           document.getLong("itineraryPrivacy") ?: createItineraryPrivacy(document.id)
+      val interest =
+          document.data["interests"] as? List<String>
+              ?: throw IllegalStateException("Interests is missing")
+      val travelStyle =
+          document.data["travelStyle"] as? List<String>
+              ?: throw IllegalStateException("Travel style is missing")
+      val languages =
+          document.data["languages"] as? List<String>
+              ?: throw IllegalStateException("Languages is missing")
 
       val userProfile =
           UserProfile(
@@ -212,7 +229,10 @@ open class UserProfileRepository {
               following,
               favoritesPaths,
               profilePrivacy.toInt(),
-              itineraryPrivacy.toInt())
+              itineraryPrivacy.toInt(),
+              interest,
+              travelStyle,
+              languages)
       _userProfileList.add(userProfile)
     }
   }

--- a/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
@@ -121,13 +121,13 @@ open class UserProfileRepository {
         document.getLong("itineraryPrivacy") ?: createItineraryPrivacy(document.id)
     val interest =
         document.data?.get("interests") as? List<String>
-            ?: throw IllegalStateException("Interests is missing")
+            ?: createEmptyList(document.id, "interests")
     val travelStyle =
         document.data?.get("travelStyle") as? List<String>
-            ?: throw IllegalStateException("Travel style is missing")
+            ?: createEmptyList(document.id, "travelStyle")
     val languages =
         document.data?.get("languages") as? List<String>
-            ?: throw IllegalStateException("Languages is missing")
+            ?: createEmptyList(document.id, "languages")
 
     return UserProfile(
         document.id,
@@ -176,6 +176,22 @@ open class UserProfileRepository {
     return itineraryPrivacy
   }
 
+    /**
+     * This function creates an empty list for the specified parameter.
+     *
+     * @param id : Unique identifier of the user's profile
+     * @param parameter : Parameter to create an empty list for
+     */
+  private fun createEmptyList(id: String, parameter: String): List<String> {
+    val emptyList = mutableListOf<String>()
+    userProfileDb
+        .document(id)
+        .update(parameter, emptyList)
+        .addOnSuccessListener { Log.d(TAG, "$parameter created successfully") }
+        .addOnFailureListener { e -> Log.e(TAG, "Error creating $parameter", e) }
+    return emptyList
+  }
+
   /**
    * This function converts the QuerySnapshot to a list of user's profiles.
    *
@@ -209,13 +225,13 @@ open class UserProfileRepository {
           document.getLong("itineraryPrivacy") ?: createItineraryPrivacy(document.id)
       val interest =
           document.data["interests"] as? List<String>
-              ?: throw IllegalStateException("Interests is missing")
+              ?: createEmptyList(document.id, "interests")
       val travelStyle =
           document.data["travelStyle"] as? List<String>
-              ?: throw IllegalStateException("Travel style is missing")
+              ?: createEmptyList(document.id, "travelStyle")
       val languages =
           document.data["languages"] as? List<String>
-              ?: throw IllegalStateException("Languages is missing")
+              ?: createEmptyList(document.id, "languages")
 
       val userProfile =
           UserProfile(

--- a/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/UserProfileRepository.kt
@@ -176,12 +176,12 @@ open class UserProfileRepository {
     return itineraryPrivacy
   }
 
-    /**
-     * This function creates an empty list for the specified parameter.
-     *
-     * @param id : Unique identifier of the user's profile
-     * @param parameter : Parameter to create an empty list for
-     */
+  /**
+   * This function creates an empty list for the specified parameter.
+   *
+   * @param id : Unique identifier of the user's profile
+   * @param parameter : Parameter to create an empty list for
+   */
   private fun createEmptyList(id: String, parameter: String): List<String> {
     val emptyList = mutableListOf<String>()
     userProfileDb
@@ -224,14 +224,12 @@ open class UserProfileRepository {
       val itineraryPrivacy =
           document.getLong("itineraryPrivacy") ?: createItineraryPrivacy(document.id)
       val interest =
-          document.data["interests"] as? List<String>
-              ?: createEmptyList(document.id, "interests")
+          document.data["interests"] as? List<String> ?: createEmptyList(document.id, "interests")
       val travelStyle =
           document.data["travelStyle"] as? List<String>
               ?: createEmptyList(document.id, "travelStyle")
       val languages =
-          document.data["languages"] as? List<String>
-              ?: createEmptyList(document.id, "languages")
+          document.data["languages"] as? List<String> ?: createEmptyList(document.id, "languages")
 
       val userProfile =
           UserProfile(

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileEditScreen.kt
@@ -69,6 +69,7 @@ import com.example.triptracker.model.profile.MutableUserProfile
 import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.NavigationBar
+import com.example.triptracker.view.profile.subviews.DropdownSelector
 import com.example.triptracker.view.theme.Montserrat
 import com.example.triptracker.view.theme.md_theme_grey
 import com.example.triptracker.view.theme.md_theme_light_dark
@@ -117,6 +118,15 @@ fun UserProfileEditScreen(
 
   /* Mutable state variable that holds the image url of the user profile */
   var imageUrl by remember { mutableStateOf(profile.userProfile.value.profileImageUrl) }
+
+  /* Mutable state variable that holds the user's interests list */
+  var selectedInterests by remember { mutableStateOf(profile.userProfile.value.interests) }
+
+  /* Mutable state variable that holds the user's travel style list */
+  var selectedTravelStyle by remember { mutableStateOf(profile.userProfile.value.travelStyle) }
+
+  /* Mutable state variable that holds the user's languages list */
+  var selectedLanguages by remember { mutableStateOf(profile.userProfile.value.languages) }
 
   /* Mutable state variable that holds the loading state of the screen */
   var isLoading by remember { mutableStateOf(false) }
@@ -352,6 +362,37 @@ fun UserProfileEditScreen(
                             })
                       }
                     }
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    DropdownSelector(
+                        label = "Interests",
+                        options = Interests.entries,
+                        selectedOptions = selectedInterests,
+                        onOptionSelected = { selectedInterests = it as List<String> },
+                        placeholder = "No Interests",
+                        modifier = Modifier.padding(start = 30.dp, end = 30.dp))
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    DropdownSelector(
+                        label = "Travel style",
+                        options = TravelStyle.entries,
+                        selectedOptions = selectedTravelStyle,
+                        onOptionSelected = { selectedTravelStyle = it },
+                        placeholder = "No Travel Style",
+                        modifier = Modifier.padding(start = 30.dp, end = 30.dp))
+
+                    Spacer(modifier = Modifier.height(10.dp))
+
+                    DropdownSelector(
+                        label = "Languages",
+                        options = Languages.entries,
+                        selectedOptions = selectedLanguages,
+                        onOptionSelected = { selectedLanguages = it as List<String> },
+                        placeholder = "No Languages",
+                        modifier = Modifier.padding(start = 30.dp, end = 30.dp))
+
                     Box(
                         modifier = Modifier.fillMaxWidth().height(200.dp),
                         contentAlignment = Alignment.Center) {
@@ -371,7 +412,10 @@ fun UserProfileEditScreen(
                                         username = username,
                                         profileImageUrl = imageUrl,
                                         followers = profile.userProfile.value.followers,
-                                        following = profile.userProfile.value.following)
+                                        following = profile.userProfile.value.following,
+                                        interests = selectedInterests,
+                                        travelStyle = selectedTravelStyle,
+                                        languages = selectedLanguages)
                                 userProfileViewModel.tryToUpdateProfile(
                                     navigation = navigation,
                                     isCreated = isCreated,

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileOverview.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -30,7 +31,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
@@ -145,10 +147,11 @@ fun UserProfileOverview(
 
                     // Profile picture and user information
                     ProfileInfoView(navigation, profile.userProfile.value)
+                    Spacer(modifier = Modifier.height(20.dp))
                     // Number of trips, followers and following when implemented in the data classes
                     ProfileCounts(navigation, profile.userProfile.value, myTripsCount)
-                    // Favourites, Friends, Settings and MyTrips tiles
                   }
+              // Favourites, Friends, Settings and MyTrips tiles
               Column(
                   modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.55).dp),
                   horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileUtils.kt
@@ -101,3 +101,44 @@ fun secondaryContentStyle(size: Int): TextStyle {
       textAlign = TextAlign.Right,
       letterSpacing = (size * 0.0005f).sp)
 }
+
+/** This class contains all the selectable interests */
+enum class Interests {
+  Walking,
+  Hiking,
+  Running,
+  Cycling,
+  Photography,
+  Food,
+  Culture,
+  Nature
+}
+
+/** This class contains all the selectable travel styles */
+enum class TravelStyle {
+    Adventurous,
+    Cultural,
+    Relaxing,
+    Solo,
+    Group,
+    Backpacking,
+    RoadTrip,
+    Camping,
+    Luxury,
+}
+
+/** This class contains all the selectable languages */
+enum class Languages {
+  French,
+  English,
+  Spanish,
+  Italian,
+  German,
+  Portuguese,
+  Dutch,
+  Russian,
+  Chinese,
+  Japanese,
+  Korean,
+  Arabic
+}

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileUtils.kt
@@ -104,41 +104,41 @@ fun secondaryContentStyle(size: Int): TextStyle {
 
 /** This class contains all the selectable interests */
 enum class Interests {
-  Walking,
-  Hiking,
-  Running,
-  Cycling,
-  Photography,
-  Food,
   Culture,
-  Nature
+  Cycling,
+  Food,
+  Hiking,
+  Nature,
+  Photography,
+  Running,
+  Walking
 }
 
 /** This class contains all the selectable travel styles */
 enum class TravelStyle {
-    Adventurous,
-    Cultural,
-    Relaxing,
-    Solo,
-    Group,
-    Backpacking,
-    RoadTrip,
-    Camping,
-    Luxury,
+  Adventurous,
+  Backpacking,
+  Camping,
+  Cultural,
+  Group,
+  Luxury,
+  Relaxing,
+  RoadTrip,
+  Solo
 }
 
 /** This class contains all the selectable languages */
 enum class Languages {
-  French,
-  English,
-  Spanish,
-  Italian,
-  German,
-  Portuguese,
-  Dutch,
-  Russian,
+  Arabic,
   Chinese,
+  Dutch,
+  English,
+  French,
+  German,
+  Italian,
   Japanese,
   Korean,
-  Arabic
+  Portuguese,
+  Russian,
+  Spanish,
 }

--- a/app/src/main/java/com/example/triptracker/view/profile/subviews/DropDownSelector.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/subviews/DropDownSelector.kt
@@ -71,17 +71,15 @@ fun <T> DropdownSelector(
         placeholder = { Text(placeholder) },
         trailingIcon = {
           IconButton(
-              onClick = { expanded = !expanded },
-              modifier = Modifier.testTag("DropDownButton")
-          ) {
-            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
-          }
+              onClick = { expanded = !expanded }, modifier = Modifier.testTag("DropDownButton")) {
+                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+              }
         },
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = 65.dp)
-            .clickable { expanded = !expanded }
-            .testTag("DropDownTextField"),
+        modifier =
+            Modifier.fillMaxWidth()
+                .heightIn(min = 65.dp)
+                .clickable { expanded = !expanded }
+                .testTag("DropDownTextField"),
         textStyle =
             TextStyle(
                 color = Color.White,
@@ -101,7 +99,8 @@ fun <T> DropdownSelector(
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = { expanded = false },
-        modifier = Modifier.fillMaxWidth().background(md_theme_light_dark).testTag("DropDownMenu")) {
+        modifier =
+            Modifier.fillMaxWidth().background(md_theme_light_dark).testTag("DropDownMenu")) {
           options.forEach { option ->
             val isSelected = selectedOptions.contains(option.toString())
             DropdownMenuItem(

--- a/app/src/main/java/com/example/triptracker/view/profile/subviews/DropDownSelector.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/subviews/DropDownSelector.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -59,7 +60,7 @@ fun <T> DropdownSelector(
         fontFamily = Montserrat,
         fontWeight = FontWeight.Normal,
         color = md_theme_grey,
-        modifier = Modifier.padding(bottom = 4.dp),
+        modifier = Modifier.padding(bottom = 4.dp).testTag("Label"),
     )
     OutlinedTextField(
         value =
@@ -69,11 +70,18 @@ fun <T> DropdownSelector(
         readOnly = true,
         placeholder = { Text(placeholder) },
         trailingIcon = {
-          IconButton(onClick = { expanded = !expanded }) {
+          IconButton(
+              onClick = { expanded = !expanded },
+              modifier = Modifier.testTag("DropDownButton")
+          ) {
             Icon(Icons.Default.ArrowDropDown, contentDescription = null)
           }
         },
-        modifier = Modifier.fillMaxWidth().heightIn(min = 65.dp).clickable { expanded = !expanded },
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 65.dp)
+            .clickable { expanded = !expanded }
+            .testTag("DropDownTextField"),
         textStyle =
             TextStyle(
                 color = Color.White,
@@ -93,10 +101,11 @@ fun <T> DropdownSelector(
     DropdownMenu(
         expanded = expanded,
         onDismissRequest = { expanded = false },
-        modifier = Modifier.fillMaxWidth().background(md_theme_light_dark)) {
+        modifier = Modifier.fillMaxWidth().background(md_theme_light_dark).testTag("DropDownMenu")) {
           options.forEach { option ->
             val isSelected = selectedOptions.contains(option.toString())
             DropdownMenuItem(
+                modifier = Modifier.testTag("DropDownMenuItem$option"),
                 text = {
                   Text(option.toString(), color = if (isSelected) md_theme_orange else Color.White)
                 },

--- a/app/src/main/java/com/example/triptracker/view/profile/subviews/DropDownSelector.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/subviews/DropDownSelector.kt
@@ -1,0 +1,115 @@
+package com.example.triptracker.view.profile.subviews
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.triptracker.view.theme.Montserrat
+import com.example.triptracker.view.theme.md_theme_grey
+import com.example.triptracker.view.theme.md_theme_light_dark
+import com.example.triptracker.view.theme.md_theme_orange
+
+/**
+ * This composable function displays a drop-down selector.
+ *
+ * @param label : the label of the drop-down selector.
+ * @param options : the list of elements to display in the drop-down selector
+ * @param selectedOptions : the list of elements the user has selected
+ * @param onOptionSelected :
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun <T> DropdownSelector(
+    label: String,
+    options: List<T>,
+    selectedOptions: List<String>,
+    onOptionSelected: (List<String>) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier
+) {
+  var expanded by remember { mutableStateOf(false) }
+
+  Column(modifier = modifier) {
+    Text(
+        text = label,
+        fontSize = 14.sp,
+        fontFamily = Montserrat,
+        fontWeight = FontWeight.Normal,
+        color = md_theme_grey,
+        modifier = Modifier.padding(bottom = 4.dp),
+    )
+    OutlinedTextField(
+        value =
+            if (selectedOptions.isEmpty()) placeholder
+            else selectedOptions.joinToString(", ") { it.toString() },
+        onValueChange = {},
+        readOnly = true,
+        placeholder = { Text(placeholder) },
+        trailingIcon = {
+          IconButton(onClick = { expanded = !expanded }) {
+            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+          }
+        },
+        modifier = Modifier.fillMaxWidth().heightIn(min = 65.dp).clickable { expanded = !expanded },
+        textStyle =
+            TextStyle(
+                color = Color.White,
+                fontSize = 16.sp,
+                fontFamily = Montserrat,
+                fontWeight = FontWeight.Normal),
+        colors =
+            TextFieldDefaults.outlinedTextFieldColors(
+                unfocusedTextColor = md_theme_grey,
+                unfocusedBorderColor = md_theme_grey,
+                unfocusedLabelColor = md_theme_grey,
+                cursorColor = md_theme_grey,
+                focusedBorderColor = md_theme_grey,
+                focusedLabelColor = Color.White,
+            ),
+    )
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+        modifier = Modifier.fillMaxWidth().background(md_theme_light_dark)) {
+          options.forEach { option ->
+            val isSelected = selectedOptions.contains(option.toString())
+            DropdownMenuItem(
+                text = {
+                  Text(option.toString(), color = if (isSelected) md_theme_orange else Color.White)
+                },
+                onClick = {
+                  val newSelection =
+                      if (isSelected) {
+                        selectedOptions - option.toString()
+                      } else {
+                        selectedOptions + option.toString()
+                      }
+                  onOptionSelected(newSelection)
+                })
+          }
+        }
+  }
+}

--- a/app/src/main/java/com/example/triptracker/view/profile/subviews/ProfileCounts.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/subviews/ProfileCounts.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
@@ -37,11 +38,12 @@ fun ProfileCounts(
 ) {
   Row(
       modifier =
-          Modifier.height((LocalConfiguration.current.screenHeightDp * 0.1f).dp).fillMaxWidth(),
+          Modifier.height((LocalConfiguration.current.screenHeightDp * 0.12f).dp).fillMaxWidth(),
       horizontalArrangement = Arrangement.Center) {
         Column(
             modifier =
                 Modifier.align(Alignment.CenterVertically)
+                    .fillMaxHeight()
                     .width((LocalConfiguration.current.screenWidthDp * 0.33f).dp)) {
               Text(
                   text = "$tripsCount",
@@ -55,11 +57,11 @@ fun ProfileCounts(
         Column(
             modifier =
                 Modifier.align(Alignment.CenterVertically)
+                    .fillMaxHeight()
                     .width((LocalConfiguration.current.screenWidthDp * 0.33f).dp)
                     .clickable(enabled = currentUserProfile) {
-                      // Navigate to the followers screen if the user displayed is the user logged
-                      // in
-
+                      // Navigate to the followers screen if the user displayed is the user
+                      // logged-in
                       navigation.navController.navigate(Route.FOLLOWERS)
                     }) {
               Text(
@@ -74,10 +76,11 @@ fun ProfileCounts(
         Column(
             modifier =
                 Modifier.align(Alignment.CenterVertically)
+                    .fillMaxHeight()
                     .width((LocalConfiguration.current.screenWidthDp * 0.33f).dp)
                     .clickable(enabled = currentUserProfile) {
-                      // Navigate to the following screen if the user displayed is the user logged
-                      // in
+                      // Navigate to the following screen if the user displayed is the user
+                      // logged-in
                       navigation.navController.navigate(Route.FOLLOWING)
                     }) {
               Text(

--- a/app/src/main/java/com/example/triptracker/view/profile/subviews/ProfileInfoView.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/subviews/ProfileInfoView.kt
@@ -122,7 +122,12 @@ fun ProfileInfoView(navigation: Navigation, userProfile: UserProfile, editable: 
                   .padding(end = (LocalConfiguration.current.screenHeightDp * 0.033f).dp)
                   .testTag("InterestTitle"))
       Text(
-          text = "Hiking, Photography", // profile.interestsList
+          text =
+              if (userProfile.interests.isEmpty()) {
+                "No interests"
+              } else {
+                userProfile.interests.joinToString(separator = ", ")
+              },
           style = secondaryContentStyle(LocalConfiguration.current.screenHeightDp),
           modifier =
               Modifier.align(Alignment.End)
@@ -139,7 +144,12 @@ fun ProfileInfoView(navigation: Navigation, userProfile: UserProfile, editable: 
                   .padding(end = (LocalConfiguration.current.screenHeightDp * 0.033f).dp)
                   .testTag("TravelStyleTitle"))
       Text(
-          text = "Adventure, Cultural", // profile.travelStyleList
+          text =
+              if (userProfile.travelStyle.isEmpty()) {
+                "No travel style"
+              } else {
+                userProfile.travelStyle.joinToString(separator = ", ")
+              },
           style = secondaryContentStyle(LocalConfiguration.current.screenHeightDp),
           modifier =
               Modifier.align(Alignment.End)
@@ -156,7 +166,12 @@ fun ProfileInfoView(navigation: Navigation, userProfile: UserProfile, editable: 
                   .padding(end = (LocalConfiguration.current.screenHeightDp * 0.033f).dp)
                   .testTag("LanguagesTitle"))
       Text(
-          text = "English, Spanish", // profile.languagesList
+          text =
+              if (userProfile.languages.isEmpty()) {
+                "No languages"
+              } else {
+                userProfile.languages.joinToString(separator = ", ")
+              },
           style = secondaryContentStyle(LocalConfiguration.current.screenHeightDp),
           modifier =
               Modifier.align(Alignment.End)


### PR DESCRIPTION
**Corresponding issue : #235** 

With this PR the user will now be able to personnalise his/her profile further than before.
The following files have been modified to create the necessary backend :
     - `UserProfile` : added the interests/travel style/languages parameters 
     - `UserProfileRepository` : added function to add empty lists for the new parameters to the users already created 
     - `UserProfileUtils` : added enumerations for the difference interests/travel style/languages that the user can select

The following views have been modified/added to allow the user to reflect the backend changes : 
     - `UserProfileEditScreen` : the edit view now allows the user to select interests/travel style/languages to personnalise his/her profile
     - `DropDownSelector` : a composable used to display the interests/travel style/languages selected by the user and allow him/her to easily select new ones/unselect current ones
     - `ProfileInfoView` : the interests/travel style/languages now display the ones from the user and not some hardcoded values
     - `UserProfileOverview` : just a small modification to make the view nicer
     - `ProfileCounts` : just some small modifications to make the view nicer 

The following tests have been modified/added : 
     - `UserProfileTest` : added assertion to ensure that interests/travel style/languages are initialised to empty lists event when not specified
     - `UserProfileEditScreenTest` : added some tests for the new components in the edit view
     - `DropDownSelectorTest` : created tests to ensure all the elements are correctly displayed in each of the three cases (interests/travel style/languages)

