### PR TITLE
Refresh the My Trips screen when a path is deleted. Fix the navigation in the profile screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ android {
   }
 
   testOptions {
+    animationsDisabled = true
     unitTests {
       isIncludeAndroidResources = true
       isReturnDefaultValues = false

--- a/app/src/androidTest/java/com/example/triptracker/view/NavigationBarTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/view/NavigationBarTest.kt
@@ -48,6 +48,7 @@ class NavigationBarTest {
         TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile")
 
     every { navigation.navigateTo(any()) } returns Unit
+    every { navigation.goBack() } returns Unit
 
     connectionMock = mockk(relaxed = true)
 

--- a/app/src/androidTest/java/com/example/triptracker/view/NavigationBarTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/view/NavigationBarTest.kt
@@ -98,6 +98,7 @@ class NavigationBarTest {
     verify { navigation.getTopLevelDestinations() }
 
     composeTestRule.onNodeWithText("Profile").performClick()
+    verify { navigation.goBack() }
     verify {
       navigation.navigateTo(TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile"))
     }
@@ -107,6 +108,7 @@ class NavigationBarTest {
     verify { navigation.getCurrentDestination() }
 
     composeTestRule.onNodeWithText("Home").performClick()
+    verify { navigation.goBack() }
     verify { navigation.navigateTo(TopLevelDestination(Route.HOME, Icons.Outlined.Home, "Home")) }
     verify { navigation.getCurrentDestination() }
     verify { navigation.getCurrentDestination() }

--- a/app/src/main/java/com/example/triptracker/model/repository/ItineraryRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/ItineraryRepository.kt
@@ -209,11 +209,14 @@ open class ItineraryRepository {
   }
 
   // Remove an itinerary from the database
-  fun removeItinerary(id: String) {
+  fun removeItinerary(id: String, callback: () -> Unit = {}) {
     db.collection("itineraries")
         .document(id)
         .delete()
-        .addOnSuccessListener { Log.d(TAG, "Itinerary removed successfully") }
+        .addOnSuccessListener {
+          Log.d(TAG, "Itinerary removed successfully")
+          callback()
+        }
         .addOnFailureListener { e -> Log.e(TAG, "Error removing itinerary", e) }
   }
 

--- a/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
+++ b/app/src/main/java/com/example/triptracker/view/NavigationBar.kt
@@ -29,7 +29,10 @@ fun NavigationBar(navigation: Navigation, connection: Connection = Connection())
               icon = { Icon(destination.icon, contentDescription = destination.textId) },
               label = { Text(destination.textId) },
               selected = navigation.getCurrentDestination().route == destination.route,
-              onClick = { navigation.navigateTo(destination) })
+              onClick = {
+                if (destination.route == Route.PROFILE) navigation.goBack()
+                navigation.navigateTo(destination)
+              })
         }
       })
 }

--- a/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
@@ -100,8 +100,8 @@ fun DisplayItinerary(
     homeViewModel: HomeViewModel = viewModel(),
     displayImage: Boolean = false,
     canBeDeleted: Boolean = false,
+    navigation: Navigation,
     onDelete: () -> Unit = {}
-    navigation: Navigation
 ) {
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp.dp

--- a/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeUtils.kt
@@ -93,6 +93,7 @@ fun DisplayItinerary(
     displayImage: Boolean = false,
     test: Boolean = false,
     canBeDeleted: Boolean = false,
+    onDelete: () -> Unit = {}
 ) {
   val configuration = LocalConfiguration.current
   val screenWidth = configuration.screenWidthDp.dp
@@ -122,7 +123,7 @@ fun DisplayItinerary(
       ShowAlert(
           onDismiss = { showAlert = false },
           onConfirm = {
-            homeViewModel.deleteItinerary(itinerary.id)
+            onDelete()
             showAlert = false
           })
     }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileScreenUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileScreenUtils.kt
@@ -112,7 +112,13 @@ fun UserProfileScreen(
                           itinerary = itinerary,
                           onClick = { navigation.navigateTo(Route.MAPS, itinerary.id) },
                           test = test,
-                          canBeDeleted = true)
+                          canBeDeleted = canBeDeleted(filterType),
+                          onDelete = {
+                            homeViewModel.deleteItinerary(itinerary.id) {
+                              homeViewModel.setSearchFilter(filterType)
+                              homeViewModel.setSearchQuery(userProfile.userProfile.value.username)
+                            }
+                          })
                     }
                   }
             }
@@ -149,4 +155,13 @@ fun UserProfileScreen(
               }
         }
       }
+}
+
+/**
+ * This function checks if the filter type can be deleted.
+ *
+ * @param filterType FilterType object for filtering the user's trips.
+ */
+private fun canBeDeleted(filterType: FilterType): Boolean {
+  return filterType == FilterType.USERNAME
 }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileScreenUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileScreenUtils.kt
@@ -98,7 +98,6 @@ fun UserProfileScreen(
                       DisplayItinerary(
                           itinerary = itinerary,
                           onClick = { navigation.navigateTo(Route.MAPS, itinerary.id) },
-                          test = test,
                           canBeDeleted = canBeDeleted(filterType),
                           navigation = navigation,
                           onDelete = {

--- a/app/src/main/java/com/example/triptracker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/triptracker/viewmodel/HomeViewModel.kt
@@ -362,10 +362,9 @@ class HomeViewModel(private val repository: ItineraryRepository = ItineraryRepos
   //    _itineraryList.value = itineraryList.value?.sortedByDescending { it.flameCount }
   //  }
 
-  fun deleteItinerary(itineraryId: String) {
+  fun deleteItinerary(itineraryId: String, callback: () -> Unit = {}) {
     viewModelScope.launch {
-      repository.removeItinerary(itineraryId)
-      fetchItineraries()
+      repository.removeItinerary(itineraryId) { fetchItineraries() { callback() } }
     }
   }
 }


### PR DESCRIPTION
This PR will : 
- Fix the refresh of the My trips UI once a trip is deleted. Now the delete triggers a recomposition of the screen and display the changes in real time.
- When navigating on subscreens of the profile screen and then changing to maps / record or home, returning back to the profile reloads the same screen as it was left. Now on click on the profile it will always show the start screen.