### PR TITLE
Home Tests 

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -575,11 +575,7 @@ class HomeTest {
         }
 
     composeTestRule.setContent {
-      HomePager(
-          navigation = mockNav,
-          homeViewModel = mockViewModel,
-          innerPadding = PaddingValues(0.dp),
-          test = true)
+      HomePager(navigation = mockNav, homeViewModel = mockViewModel, test = true)
       HomeScreen(navigation = mockNav, homeViewModel = mockViewModel, test = true)
     }
 
@@ -617,11 +613,7 @@ class HomeTest {
           homeViewModel = mockViewModel,
           userProfileViewModel = mockUserProfileViewModel,
           test = false)
-      HomePager(
-          navigation = mockNav,
-          homeViewModel = mockViewModel,
-          innerPadding = PaddingValues(0.dp),
-          test = false)
+      HomePager(navigation = mockNav, homeViewModel = mockViewModel, test = false)
     }
     composeTestRule.onNodeWithTag("HomePager").performTouchInput { swipeLeft() }
   }

--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -105,6 +105,7 @@ class HomeTest {
         }
   }
 
+  /** This test checks if the home screen components are displayed correctly */
   @Test
   fun homeScreenComponentsAreDisplayed() {
     // Have to repeat code to have specific mock data for each test!!
@@ -143,6 +144,7 @@ class HomeTest {
     }
   }
 
+  /** This test checks if itinerary is displayed and clicks on it */
   @Test
   fun clickingOnItineraryOpensItineraryPreview() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -169,6 +171,7 @@ class HomeTest {
     }
   }
 
+  /** This test checks if the profile picture is displayed and clicks on it */
   @Test
   fun clickingOnProfilePictureOpensPreview() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -202,6 +205,10 @@ class HomeTest {
     }
   }
 
+  /**
+   * This test checks if the search bar is displayed correctly and if the search bar text is
+   * displayed correctly
+   */
   @Test
   fun testSearchBarDisplaysComponentsCorrectly() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -225,6 +232,7 @@ class HomeTest {
     composeTestRule.onNodeWithTag("searchBarText", useUnmergedTree = true).assertIsDisplayed()
   }
 
+  /** This test checks if the search bar is displayed correctly */
   @Test
   fun searchBarIsDisplayed() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -242,10 +250,7 @@ class HomeTest {
       HomeScreen(navigation = mockNav, homeViewModel = mockViewModel, test = true)
     }
     ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) {
-      searchBar {
-        assertIsDisplayed()
-        // This test is failing because of an internal error in Firestore
-      }
+      searchBar { assertIsDisplayed() }
     }
   }
 
@@ -281,6 +286,7 @@ class HomeTest {
     }
   }
 
+  /** This checks if itinerary is clickable */
   @Test
   fun itineraryIsClickable() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -301,6 +307,7 @@ class HomeTest {
     ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) { itinerary { performClick() } }
   }
 
+  /** This test checks if no itineraries text is displayed when there are no itineraries */
   @Test
   fun noItinerariesTextIsDisplayed() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -321,6 +328,7 @@ class HomeTest {
     }
   }
 
+  /** This test clicks on the profile icon */
   @Test
   fun profileIconClickOpensProfileScreen() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -352,6 +360,12 @@ class HomeTest {
           // Invoke the callback with mock data
           val callback = arg<(List<Itinerary>) -> Unit>(0)
           callback(mockItineraries)
+        }
+    every { mockUserProfileViewModel.fetchAllUserProfiles(any()) } answers
+        {
+          // Invoke the callback with mock data
+          val callback = arg<(List<UserProfile>) -> Unit>(0)
+          callback(mockUsers)
         }
     every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
     every { mockViewModel.filteredItineraryList } returns filteredItineraryLiveData
@@ -387,6 +401,10 @@ class HomeTest {
     }
   }
 
+  /**
+   * This test checks if the search bar is displayed correctly and if the search bar text is
+   * displayed correctly Check if itineraries are displayed.
+   */
   @Test
   fun clickOnDropDownMenu() {
     every { mockItineraryRepository.getAllItineraries(any()) } answers
@@ -398,6 +416,7 @@ class HomeTest {
     every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
     every { mockViewModel.filteredItineraryList } returns MutableLiveData(mockItineraries)
     every { mockProfile.userProfile.value } returns mockUsers[0]
+
     // Setting up the test composition
     composeTestRule.setContent {
       HomeScreen(navigation = mockNav, homeViewModel = mockViewModel, test = true)
@@ -406,14 +425,21 @@ class HomeTest {
       searchBar {
         assertIsDisplayed()
         performClick()
+        pressKey(84)
+        composeTestRule.waitForIdle()
       }
+
+      every { mockViewModel.searchQuery } returns MutableLiveData("Tr")
       composeTestRule
           .onNodeWithTag("DropDownBox", useUnmergedTree = true)
           .assertIsDisplayed()
           .performClick()
+
+      // composeTestRule.onNodeWithTag("DropDownFilter").performClick().assertIsDisplayed()
     }
   }
 
+  /** This test checks if no results are displayed when searching for an inexistent itinerary */
   @Test
   fun noResultWhenSearchingForInexistantItinerary() {
     try {
@@ -453,6 +479,7 @@ class HomeTest {
     }
   }
 
+  /** This test checks if no results are displayed when searching for a non-existent itinerary */
   @Test
   fun noResultWhenSearchingForNonExistentItinerary() {
     try {
@@ -506,6 +533,7 @@ class HomeTest {
     composeTestRule.onNodeWithText("FOLLOWING", useUnmergedTree = true).assertIsDisplayed()
   }
 
+  /** This test clicks on the following tab */
   @Test
   fun testClickOnFollowing() {
     every { mockViewModel.itineraryList } returns MutableLiveData(emptyList())
@@ -519,6 +547,7 @@ class HomeTest {
     composeTestRule.onNodeWithText("FOLLOWING", useUnmergedTree = true).performClick()
   }
 
+  /** This test swipes left on the pager */
   @Test
   fun testSwipeLeft() {
     composeTestRule.setContent {
@@ -530,6 +559,82 @@ class HomeTest {
     }
 
     // Find the node representing the pager
+    composeTestRule.onNodeWithTag("HomePager").performTouchInput { swipeLeft() }
+  }
+
+  /** This test swipes left on the pager with non-empty itineraries */
+  @Test
+  fun SwipeLeftWithItineraries() {
+    every { mockUserProfileViewModel.getUserProfile(mockMail) {} } returns
+        mockk(relaxUnitFun = true)
+
+    every { mockItineraryRepository.getAllItineraries(any()) } answers
+        {
+          // Invoke the callback with mock data
+          val callback = arg<(List<Itinerary>) -> Unit>(0)
+          callback(mockItineraries)
+        }
+    every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.filteredItineraryList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.trendingList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.followingList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.searchQuery } returns MutableLiveData("test")
+    every { mockUserProfileViewModel.fetchAllUserProfiles(any()) } answers
+        {
+          // Invoke the callback with mock data
+          val callback = arg<(List<UserProfile>) -> Unit>(0)
+          callback(mockUsers)
+        }
+
+    composeTestRule.setContent {
+      HomePager(
+          navigation = mockNav,
+          homeViewModel = mockViewModel,
+          innerPadding = PaddingValues(0.dp),
+          test = true)
+      HomeScreen(navigation = mockNav, homeViewModel = mockViewModel, test = true)
+    }
+
+    ComposeScreen.onComposeScreen<HomeViewScreen>(composeTestRule) {
+      itinerary {
+        assertIsDisplayed()
+        performClick()
+      }
+    }
+
+    composeTestRule.onNodeWithTag("HomePager").performTouchInput { swipeLeft() }
+  }
+
+  /** This covers uncovered code in HomeScreen */
+  @Test
+  fun testWithBooleanFalseHomeScreen() {
+    // Have to repeat code to have specific mock data for each test!!
+    every { mockUserProfileRepository.getUserProfileByEmail(mockMail) {} } returns
+        mockk(relaxUnitFun = true)
+    // this removes previous problem
+    every { mockItineraryRepository.getAllItineraries(any()) } answers
+        {
+          // Invoke the callback with mock data
+          val callback = arg<(List<Itinerary>) -> Unit>(0)
+          callback(mockItineraries)
+        }
+    every { mockViewModel.itineraryList } returns MutableLiveData(mockItineraries)
+    every { mockViewModel.filteredItineraryList } returns MutableLiveData(mockItineraries)
+    every { mockProfile.userProfile.value } returns mockUsers[0]
+
+    // Setting up the test composition
+    composeTestRule.setContent {
+      HomeScreen(
+          navigation = mockNav,
+          homeViewModel = mockViewModel,
+          userProfileViewModel = mockUserProfileViewModel,
+          test = false)
+      HomePager(
+          navigation = mockNav,
+          homeViewModel = mockViewModel,
+          innerPadding = PaddingValues(0.dp),
+          test = false)
+    }
     composeTestRule.onNodeWithTag("HomePager").performTouchInput { swipeLeft() }
   }
 }

--- a/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/screens/home/HomeTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.outlined.Place
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -642,9 +643,10 @@ class HomeTest {
         composeTestRule.waitForIdle()
         // Interact with the dropdown menu
         composeTestRule.onNodeWithTag("DropDownBox").performClick()
-        composeTestRule.onNodeWithText("TITLE").assertIsDisplayed()
-        // click on Dropdown
-        composeTestRule.onNodeWithText("TITLE").performClick()
+        composeTestRule
+            .onAllNodesWithText("TITLE", useUnmergedTree = true)[0]
+            .assertIsDisplayed()
+            .performClick()
         composeTestRule.onNodeWithText("USERNAME").assertIsDisplayed().performClick()
       }
     }


### PR DESCRIPTION
This PR brings back the home package coverage to 81%.

Changes:
- Comments are added on each test
- 4 new tests:
    - `SwipeLeftWithItineraries` swipes left on home pager with itineraries in following and trending pages
    - `testWithBooleanFalseHomeScreen` to reach uncovered lines 
    - `clickOnDropDownMenuDisplaysFilters` clicks on the dropdown in search bar and selects username filter
    - `itineraryItemDisplayed` checks if itinerary item is displayed when in search bar 

![Screenshot 2024-05-24 at 14 08 38](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/25b41211-41e8-453c-8aaa-857191a1b1cc)
