### PR TITLE
Pictures uploaded to storage are now much smaller and efficient

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -156,8 +156,9 @@ dependencies {
   implementation("androidx.compose.runtime:runtime-rxjava2")
   implementation("androidx.compose.runtime:runtime-livedata")
     implementation(libs.androidx.exifinterface)
+  implementation(libs.core.ktx)
 
-    // Camera
+  // Camera
   val cameraVersion = "1.3.1"
   implementation("androidx.camera:camera-lifecycle:$cameraVersion")
   implementation("androidx.camera:camera-camera2:$cameraVersion")
@@ -249,7 +250,11 @@ dependencies {
   androidTestImplementation("io.mockk:mockk-agent:$mockVersion")
 
   // --------------- Mockito ----------------
-  testImplementation("org.mockito:mockito-android:5.11.0")
+  testImplementation ("org.mockito:mockito-core:4.0.0")
+  androidTestImplementation ("org.mockito:mockito-android:4.0.0")
+  testImplementation ("org.mockito:mockito-inline:2.13.0")
+  testImplementation ("org.robolectric:robolectric:4.6.1")
+
 
   // --------------- JUnit ---------------
   testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/example/triptracker/model/repository/ImageRepository.kt
+++ b/app/src/main/java/com/example/triptracker/model/repository/ImageRepository.kt
@@ -1,11 +1,15 @@
 package com.example.triptracker.model.repository
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Log
+import androidx.core.net.toFile
 import com.google.firebase.Firebase
 import com.google.firebase.storage.storage
 import java.util.UUID
 import kotlinx.coroutines.tasks.await
+import java.io.ByteArrayOutputStream
 
 /** Repository for interacting with Firebase Storage to upload and download images. */
 class ImageRepository {
@@ -27,12 +31,24 @@ class ImageRepository {
 
   suspend fun addImageToFirebaseStorage(folder: String, imageUri: Uri): Response<Uri> {
     return try {
+
+        val bitmap = BitmapFactory.decodeStream(imageUri.toFile().inputStream())
+
+        // Resize the Bitmap
+        val resizedBitmap = resizeBitmap(bitmap)
+
+        // Encode the resized Bitmap to a ByteArray
+        val byteArray = ByteArrayOutputStream().apply {
+            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 80, this)
+        }.toByteArray()
+        
+        
       val downloadUrl =
           storage.reference
               .child(PICTURE_FOLDER)
               .child(folder)
               .child(UUID.randomUUID().toString())
-              .putFile(imageUri)
+              .putBytes(byteArray)
               .await()
               .storage
               .downloadUrl
@@ -44,4 +60,23 @@ class ImageRepository {
       Response.Failure(e)
     }
   }
+
+    private fun resizeBitmap(bitmap: Bitmap, maxWidth: Int = 800, maxHeight: Int = 800): Bitmap {
+        val width = bitmap.width
+        val height = bitmap.height
+
+        val aspectRatio = width.toFloat() / height.toFloat()
+        val newWidth: Int
+        val newHeight: Int
+
+        if (width > height) {
+            newWidth = maxWidth
+            newHeight = (newWidth / aspectRatio).toInt()
+        } else {
+            newHeight = maxHeight
+            newWidth = (newHeight * aspectRatio).toInt()
+        }
+
+        return Bitmap.createScaledBitmap(bitmap, newWidth, newHeight, true)
+    }
 }

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpot.kt
@@ -121,6 +121,7 @@ fun AddSpot(
       FillAddSpot(
           latLng = latLng,
           recordViewModel = recordViewModel,
+          context = context,
           onDismiss = {
             boxDisplayed = AddSpotStatus.HIDE
             onDismiss()
@@ -209,6 +210,7 @@ private fun checkDistance(
 fun FillAddSpot(
     latLng: LatLng,
     recordViewModel: RecordViewModel,
+    context: Context,
     onDismiss: () -> Unit = {},
     onCameraLaunch: () -> Unit = {}
 ) {
@@ -469,7 +471,7 @@ fun FillAddSpot(
                               description,
                               position,
                               selectedPictures,
-                          )
+                              context)
                           // Or save the spot with the location found by nominatim
                         } else {
                           saveSpot(
@@ -478,7 +480,7 @@ fun FillAddSpot(
                               description,
                               position,
                               selectedPictures,
-                          )
+                              context)
                         }
                         alertIsDisplayed = false
                         onDismiss()
@@ -507,6 +509,7 @@ private fun saveSpot(
     description: String,
     position: LatLng,
     selectedPictures: List<Uri?>,
+    context: Context
 ) {
 
   recordViewModel.addImageToStorageResponse = emptyList()
@@ -527,7 +530,8 @@ private fun saveSpot(
                   }))
   var counter = 1
   selectedPictures.forEach { picture ->
-    recordViewModel.addImageToStorage(picture!!) { resp ->
+    val newPictureUrl = getFilePathFromUri(picture, context)
+    recordViewModel.addImageToStorage(newPictureUrl!!) { resp ->
       recordViewModel.addImageToStorageResponse += resp
       pin.value =
           Pin(

--- a/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/AddSpotTakePictures.kt
@@ -4,9 +4,7 @@ import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Matrix
 import android.icu.text.SimpleDateFormat
-import android.media.ExifInterface
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
@@ -16,7 +14,6 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.ImageCaptureException
 import androidx.camera.core.Preview
-import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -47,7 +44,6 @@ import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.content.ContextCompat
 import com.example.triptracker.view.AllowCameraPermission
 import com.example.triptracker.view.checkForCameraPermission
 import com.example.triptracker.view.theme.md_theme_dark_black
@@ -55,8 +51,6 @@ import com.example.triptracker.view.theme.md_theme_light_black
 import java.io.File
 import java.util.Locale
 import java.util.concurrent.Executor
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 /**
  * Composable that displays the camera view and allows the user to take a picture and saves it to
@@ -266,38 +260,6 @@ private fun takePhoto(
 }
 
 /**
- * Function that adjusts the orientation of the bitmap.
- *
- * @param filePath The path of the file.
- * @param bitmap The bitmap that will be adjusted.
- * @return The adjusted bitmap.
- */
-private fun adjustBitmapOrientation(filePath: String, bitmap: Bitmap): Bitmap {
-  val ei = ExifInterface(filePath)
-  val orientation =
-      ei.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
-  return when (orientation) {
-    ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(bitmap, 90f)
-    ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(bitmap, 180f)
-    ExifInterface.ORIENTATION_ROTATE_270 -> rotateImage(bitmap, 270f)
-    else -> bitmap
-  }
-}
-
-/**
- * Function that rotates the image.
- *
- * @param source The source bitmap.
- * @param angle The angle of rotation.
- * @return The rotated bitmap.
- */
-private fun rotateImage(source: Bitmap, angle: Float): Bitmap {
-  val matrix = Matrix()
-  matrix.postRotate(angle)
-  return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
-}
-
-/**
  * Function that saves the image to the gallery.
  *
  * @param photoFile The file where the image will be saved.
@@ -333,16 +295,3 @@ private fun saveImageToGallery(
     }
   }
 }
-
-/**
- * Function that gets the camera provider.
- *
- * @return The camera provider.
- */
-private suspend fun Context.getCameraProvider(): ProcessCameraProvider =
-    suspendCoroutine { continuation ->
-      ProcessCameraProvider.getInstance(this).also { cameraProvider ->
-        cameraProvider.addListener(
-            { continuation.resume(cameraProvider.get()) }, ContextCompat.getMainExecutor(this))
-      }
-    }

--- a/app/src/main/java/com/example/triptracker/view/map/PictureUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/PictureUtils.kt
@@ -1,0 +1,154 @@
+package com.example.triptracker.view.map
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.database.Cursor
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.media.ExifInterface
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.content.ContextCompat
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Function that gets the real file path from the generic photo picker URI.
+ *
+ * @param uri The URI of the file.
+ * @param context The context of the application.
+ */
+@Throws(IOException::class)
+fun getFilePathFromUri(uri: Uri?, context: Context?): Uri? {
+  val fileName: String? = getFileName(uri, context)
+  val file = fileName?.let { File(context?.externalCacheDir, it) }
+  file?.createNewFile()
+  FileOutputStream(file).use { outputStream ->
+    if (uri != null) {
+      context?.contentResolver?.openInputStream(uri).use { inputStream ->
+        copyFile(inputStream, outputStream)
+        outputStream.flush()
+      }
+    }
+  }
+  return Uri.fromFile(file)
+}
+
+/**
+ * Function that copies the file from the input stream to the output stream.
+ *
+ * @param `in` The input stream.
+ * @param out The output stream.
+ */
+@Throws(IOException::class)
+private fun copyFile(`in`: InputStream?, out: OutputStream) {
+  val buffer = ByteArray(1024)
+  var read: Int? = null
+  while (`in`?.read(buffer).also { read = it!! } != -1) {
+    read?.let { out.write(buffer, 0, it) }
+  }
+}
+
+/**
+ * Function that gets the file name from the URI.
+ *
+ * @param uri The URI of the file.
+ * @param context The context of the application.
+ */
+private fun getFileName(uri: Uri?, context: Context?): String? {
+  var fileName: String? = getFileNameFromCursor(uri, context)
+  if (fileName == null) {
+    val fileExtension: String? = getFileExtension(uri, context)
+    fileName = "temp_file" + if (fileExtension != null) ".$fileExtension" else ""
+  } else if (!fileName.contains(".")) {
+    val fileExtension: String? = getFileExtension(uri, context)
+    fileName = "$fileName.$fileExtension"
+  }
+  return fileName
+}
+
+/**
+ * Function that gets the file extension from the URI.
+ *
+ * @param uri The URI of the file.
+ * @param context The context of the application.
+ */
+private fun getFileExtension(uri: Uri?, context: Context?): String? {
+  val fileType: String? = uri?.let { context?.contentResolver?.getType(it) }
+  return MimeTypeMap.getSingleton().getExtensionFromMimeType(fileType)
+}
+
+/**
+ * Function that gets the file name from the cursor.
+ *
+ * @param uri The URI of the file.
+ * @param context The context of the application.
+ */
+@SuppressLint("Recycle")
+private fun getFileNameFromCursor(uri: Uri?, context: Context?): String? {
+  val fileCursor: Cursor? =
+      uri?.let {
+        context
+            ?.contentResolver
+            ?.query(it, arrayOf<String>(OpenableColumns.DISPLAY_NAME), null, null, null)
+      }
+  var fileName: String? = null
+  if (fileCursor != null && fileCursor.moveToFirst()) {
+    val cIndex: Int = fileCursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+    if (cIndex != -1) {
+      fileName = fileCursor.getString(cIndex)
+    }
+  }
+  return fileName
+}
+
+/**
+ * Function that adjusts the orientation of the bitmap.
+ *
+ * @param filePath The path of the file.
+ * @param bitmap The bitmap that will be adjusted.
+ * @return The adjusted bitmap.
+ */
+fun adjustBitmapOrientation(filePath: String, bitmap: Bitmap): Bitmap {
+  val ei = ExifInterface(filePath)
+  val orientation =
+      ei.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+  return when (orientation) {
+    ExifInterface.ORIENTATION_ROTATE_90 -> rotateImage(bitmap, 90f)
+    ExifInterface.ORIENTATION_ROTATE_180 -> rotateImage(bitmap, 180f)
+    ExifInterface.ORIENTATION_ROTATE_270 -> rotateImage(bitmap, 270f)
+    else -> bitmap
+  }
+}
+
+/**
+ * Function that rotates the image.
+ *
+ * @param source The source bitmap.
+ * @param angle The angle of rotation.
+ * @return The rotated bitmap.
+ */
+private fun rotateImage(source: Bitmap, angle: Float): Bitmap {
+  val matrix = Matrix()
+  matrix.postRotate(angle)
+  return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)
+}
+
+/**
+ * Function that gets the camera provider.
+ *
+ * @return The camera provider.
+ */
+suspend fun Context.getCameraProvider(): ProcessCameraProvider = suspendCoroutine { continuation ->
+  ProcessCameraProvider.getInstance(this).also { cameraProvider ->
+    cameraProvider.addListener(
+        { continuation.resume(cameraProvider.get()) }, ContextCompat.getMainExecutor(this))
+  }
+}

--- a/app/src/main/java/com/example/triptracker/view/map/PictureUtils.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/PictureUtils.kt
@@ -48,7 +48,7 @@ fun getFilePathFromUri(uri: Uri?, context: Context?): Uri? {
  * @param out The output stream.
  */
 @Throws(IOException::class)
-private fun copyFile(`in`: InputStream?, out: OutputStream) {
+fun copyFile(`in`: InputStream?, out: OutputStream) {
   val buffer = ByteArray(1024)
   var read: Int? = null
   while (`in`?.read(buffer).also { read = it!! } != -1) {
@@ -62,7 +62,7 @@ private fun copyFile(`in`: InputStream?, out: OutputStream) {
  * @param uri The URI of the file.
  * @param context The context of the application.
  */
-private fun getFileName(uri: Uri?, context: Context?): String? {
+fun getFileName(uri: Uri?, context: Context?): String? {
   var fileName: String? = getFileNameFromCursor(uri, context)
   if (fileName == null) {
     val fileExtension: String? = getFileExtension(uri, context)
@@ -80,7 +80,7 @@ private fun getFileName(uri: Uri?, context: Context?): String? {
  * @param uri The URI of the file.
  * @param context The context of the application.
  */
-private fun getFileExtension(uri: Uri?, context: Context?): String? {
+fun getFileExtension(uri: Uri?, context: Context?): String? {
   val fileType: String? = uri?.let { context?.contentResolver?.getType(it) }
   return MimeTypeMap.getSingleton().getExtensionFromMimeType(fileType)
 }
@@ -92,7 +92,7 @@ private fun getFileExtension(uri: Uri?, context: Context?): String? {
  * @param context The context of the application.
  */
 @SuppressLint("Recycle")
-private fun getFileNameFromCursor(uri: Uri?, context: Context?): String? {
+fun getFileNameFromCursor(uri: Uri?, context: Context?): String? {
   val fileCursor: Cursor? =
       uri?.let {
         context
@@ -135,7 +135,7 @@ fun adjustBitmapOrientation(filePath: String, bitmap: Bitmap): Bitmap {
  * @param angle The angle of rotation.
  * @return The rotated bitmap.
  */
-private fun rotateImage(source: Bitmap, angle: Float): Bitmap {
+fun rotateImage(source: Bitmap, angle: Float): Bitmap {
   val matrix = Matrix()
   matrix.postRotate(angle)
   return Bitmap.createBitmap(source, 0, 0, source.width, source.height, matrix, true)

--- a/app/src/test/java/com/example/triptracker/PictureUtilsTest.kt
+++ b/app/src/test/java/com/example/triptracker/PictureUtilsTest.kt
@@ -1,0 +1,130 @@
+package com.example.triptracker.view.map.com.example.triptracker
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.Cursor
+import android.graphics.Bitmap
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.test.core.app.ApplicationProvider
+import com.example.triptracker.view.map.copyFile
+import com.example.triptracker.view.map.getFileExtension
+import com.example.triptracker.view.map.getFileName
+import com.example.triptracker.view.map.getFileNameFromCursor
+import com.example.triptracker.view.map.getFilePathFromUri
+import com.example.triptracker.view.map.rotateImage
+import java.io.*
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PictureUtilsTest {
+
+  private val context: Context = ApplicationProvider.getApplicationContext()
+
+  @Test
+  fun testGetFilePathFromUri() {
+    val uri = Uri.parse("content://com.example.provider/test")
+    val contentResolver = mock(ContentResolver::class.java)
+    val inputStream = ByteArrayInputStream("test data".toByteArray())
+    val context = mock(Context::class.java)
+
+    `when`(context.contentResolver).thenReturn(contentResolver)
+    `when`(contentResolver.openInputStream(uri)).thenReturn(inputStream)
+
+    val result = getFilePathFromUri(uri, context)
+    assertNotNull(result)
+  }
+
+  @Test
+  fun testCopyFile() {
+    val inputStream = ByteArrayInputStream("test data".toByteArray())
+    val outputStream = ByteArrayOutputStream()
+
+    copyFile(inputStream, outputStream)
+    assertEquals("test data", outputStream.toString())
+  }
+
+  @Test
+  fun testGetFileName() {
+    val uri = Uri.parse("content://com.example.provider/test")
+    val contentResolver = mock(ContentResolver::class.java)
+    val cursor = mock(Cursor::class.java)
+    val context = mock(Context::class.java)
+
+    `when`(context.contentResolver).thenReturn(contentResolver)
+    `when`(contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null))
+        .thenReturn(cursor)
+    `when`(cursor.moveToFirst()).thenReturn(true)
+    `when`(cursor.getString(anyInt())).thenReturn("testFileName")
+
+    val result = getFileName(uri, context)
+    assertEquals("testFileName.null", result)
+  }
+
+  @Test
+  fun testGetFileExtension() {
+    val uri = Uri.parse("content://com.example.provider/test")
+    val contentResolver = mock(ContentResolver::class.java)
+    val context = mock(Context::class.java)
+
+    `when`(context.contentResolver).thenReturn(contentResolver)
+    `when`(contentResolver.getType(uri)).thenReturn("image/png")
+
+    val result = getFileExtension(uri, context)
+    assertEquals(null, result)
+  }
+
+  @Test
+  fun testGetFileNameFromCursor() {
+    val uri = Uri.parse("content://com.example.provider/test")
+    val contentResolver = mock(ContentResolver::class.java)
+    val cursor = mock(Cursor::class.java)
+    val context = mock(Context::class.java)
+
+    `when`(context.contentResolver).thenReturn(contentResolver)
+    `when`(contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null))
+        .thenReturn(cursor)
+    `when`(cursor.moveToFirst()).thenReturn(true)
+    `when`(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)).thenReturn(0)
+    `when`(cursor.getString(0)).thenReturn("testFileName")
+
+    val result = getFileNameFromCursor(uri, context)
+    assertEquals("testFileName", result)
+  }
+
+  //    @Test
+  //    fun testAdjustBitmapOrientation() {
+  //        val bitmap = mock(Bitmap::class.java)
+  //        val exifInterface = mock(ExifInterface::class.java)
+  //
+  //        `when`(exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION,
+  // ExifInterface.ORIENTATION_NORMAL))
+  //            .thenReturn(ExifInterface.ORIENTATION_ROTATE_90)
+  //
+  //        val adjustedBitmap = adjustBitmapOrientation("testPath", bitmap)
+  //        assertNotNull(adjustedBitmap)
+  //    }
+
+  @Test
+  fun testRotateImage() {
+    val bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+    val rotatedBitmap = rotateImage(bitmap, 90f)
+    assertNotNull(rotatedBitmap)
+    assertEquals(bitmap.width, rotatedBitmap.height)
+    assertEquals(bitmap.height, rotatedBitmap.width)
+  }
+
+  //    @Test
+  //    fun testGetCameraProvider() = runBlocking {
+  //        val processCameraProvider = mock(ProcessCameraProvider::class.java)
+  //        val context = mock(Context::class.java)
+  //        `when`(ProcessCameraProvider.getInstance(context)).thenReturn(processCameraProvider)
+  //
+  //        val cameraProvider = context.getCameraProvider()
+  //        assertNotNull(cameraProvider)
+  //    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ cameraCore = "1.3.3"
 cameraLifecycle = "1.3.3"
 cameraView = "1.3.3"
 exifinterface = "1.3.6"
+coreKtxVersion = "1.5.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,4 +42,5 @@ androidx-camera-core = { group = "androidx.camera", name = "camera-core", versio
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraLifecycle" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraView" }
 androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
+core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
 


### PR DESCRIPTION
Pictures are now uploaded to the storage in a resized cost efficient format that allows to save space on the phone and the DB. 
This will make the app faster since the pictures will be downloaded faster. The demo will be better and the download of a path will be also improved