### PR TITLE
Increased the code coverage of the setting screen

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileSettingsTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/userProfile/UserProfileSettingsTest.kt
@@ -1,9 +1,10 @@
-package com.example.triptracker.screens.userProfile
+package com.example.triptracker.userProfile
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -74,5 +75,53 @@ class UserProfileSettingsTest : TestCase() {
 
     val button3 = composeTestRule.onNodeWithText("button3")
     button3.assertExists().assertHasClickAction().performClick()
+  }
+
+  @Test
+  fun pathVisibilityButtonWorks() {
+    composeTestRule.setContent { UserProfileSettings(navigation) }
+    // we ensure the button is displayed and tests its different states
+    composeTestRule
+        .onNodeWithTag("PathVisibilityButton")
+        .assertIsDisplayed()
+        .assertTextEquals("Public")
+    composeTestRule.onNodeWithTag("PathVisibilityButton").assertHasClickAction().performClick()
+    composeTestRule
+        .onNodeWithTag("PathVisibilityButton")
+        .assertIsDisplayed()
+        .assertTextEquals("Friends")
+    composeTestRule.onNodeWithTag("PathVisibilityButton").assertHasClickAction().performClick()
+    composeTestRule.onNodeWithTag("PathVisibilityButton").assertIsDisplayed().assertTextEquals("Me")
+    composeTestRule.onNodeWithTag("PathVisibilityButton").assertHasClickAction().performClick()
+    composeTestRule
+        .onNodeWithTag("PathVisibilityButton")
+        .assertIsDisplayed()
+        .assertTextEquals("Public")
+  }
+
+  @Test
+  fun profilePrivacyButtonWorks() {
+    composeTestRule.setContent { UserProfileSettings(navigation) }
+    // we ensure the button is displayed and tests its different states
+    composeTestRule
+        .onNodeWithTag("ProfilePrivacyButton")
+        .assertIsDisplayed()
+        .assertTextEquals("Public")
+    composeTestRule.onNodeWithTag("ProfilePrivacyButton").assertHasClickAction().performClick()
+    composeTestRule
+        .onNodeWithTag("ProfilePrivacyButton")
+        .assertIsDisplayed()
+        .assertTextEquals("Private")
+    composeTestRule.onNodeWithTag("ProfilePrivacyButton").assertHasClickAction().performClick()
+    composeTestRule
+        .onNodeWithTag("ProfilePrivacyButton")
+        .assertIsDisplayed()
+        .assertTextEquals("Public")
+  }
+
+  @Test
+  fun logOutButtonIsDisplayed() {
+    composeTestRule.setContent { UserProfileSettings(navigation) }
+    composeTestRule.onNodeWithTag("LogOutButton").assertIsDisplayed().assertHasClickAction()
   }
 }

--- a/app/src/main/java/com/example/triptracker/view/profile/UserProfileSettings.kt
+++ b/app/src/main/java/com/example/triptracker/view/profile/UserProfileSettings.kt
@@ -86,8 +86,10 @@ fun UserProfileSettings(
                       FilledTonalButton(
                           modifier =
                               Modifier.size(
-                                  width = (LocalConfiguration.current.screenWidthDp * 0.30).dp,
-                                  height = (LocalConfiguration.current.screenHeightDp * 0.06).dp),
+                                      width = (LocalConfiguration.current.screenWidthDp * 0.30).dp,
+                                      height =
+                                          (LocalConfiguration.current.screenHeightDp * 0.06).dp)
+                                  .testTag("ProfilePrivacyButton"),
                           onClick = {
                             setIsPrivate(!isPublic)
                             var privacy = userProfile.profilePrivacy
@@ -136,8 +138,10 @@ fun UserProfileSettings(
                           state = buttonState,
                           modifier =
                               Modifier.size(
-                                  width = (LocalConfiguration.current.screenWidthDp * 0.30).dp,
-                                  height = (LocalConfiguration.current.screenHeightDp * 0.06).dp),
+                                      width = (LocalConfiguration.current.screenWidthDp * 0.30).dp,
+                                      height =
+                                          (LocalConfiguration.current.screenHeightDp * 0.06).dp)
+                                  .testTag("PathVisibilityButton"),
                           onClick = {
                             setButtonState((buttonState + 1) % 3)
 
@@ -185,8 +189,10 @@ fun UserProfileSettings(
                       FilledTonalButton(
                           modifier =
                               Modifier.size(
-                                  width = (LocalConfiguration.current.screenWidthDp * 0.30).dp,
-                                  height = (LocalConfiguration.current.screenHeightDp * 0.06).dp),
+                                      width = (LocalConfiguration.current.screenWidthDp * 0.30).dp,
+                                      height =
+                                          (LocalConfiguration.current.screenHeightDp * 0.06).dp)
+                                  .testTag("LogOutButton"),
                           onClick = {
                             val context = MainActivity.applicationContext()
                             GoogleAuthenticator().signOut(context)


### PR DESCRIPTION
**Corresponding issue : #263** 

With this PR the code coverage of the `UserProfileSetting` view should be increased

The following testing file has been modified : 
     - `UserProfileSettingsTest` : add tests for the buttons on the screen 

The following view has been modified : 
     - `UserProfileSettings` : added the test tag to create the tests