### PR TITLE
Home fixes & others 🌸

### DIFF
--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -241,7 +241,7 @@ fun SearchBarImplementation(
     SearchBar(
         modifier =
             Modifier.fillMaxWidth()
-                .padding(horizontal = 30.dp, vertical = 5.dp)
+                .padding(horizontal = 17.dp, vertical = 5.dp)
                 .testTag("searchBar"),
         query = searchText,
         onQueryChange = { newText ->

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -130,17 +130,21 @@ fun HomeScreen(
                   isNoResultFound = isNoResultFound)
             }
             if (isSearchActive) {
-                val horizontalPlacement = LocalConfiguration.current.screenWidthDp * 0.6f
-
+              val horizontalPlacement = LocalConfiguration.current.screenWidthDp * 0.6f
+              val verticalPlacement = LocalConfiguration.current.screenHeightDp * 0.024f
               Box(
                   modifier =
-                      Modifier.padding(PaddingValues(horizontalPlacement.dp, 24.dp, 0.dp, 0.dp))
-                          .fillMaxWidth().fillMaxHeight()
+                      Modifier.padding(
+                              PaddingValues(
+                                  horizontalPlacement.dp, verticalPlacement.dp, 0.dp, 0.dp))
+                          .fillMaxWidth()
+                          .fillMaxHeight()
                           .testTag("DropDownBox")) {
                     DropdownMenu(
                         expanded = showFilterDropdown,
                         onDismissRequest = { showFilterDropdown = false },
-                        modifier = Modifier.padding(10.dp).width(400.dp).testTag("DropDownFilter")) {
+                        modifier =
+                            Modifier.padding(10.dp).width(400.dp).testTag("DropDownFilter")) {
                           FilterType.entries.forEach { filterType ->
                             DropdownMenuItem(
                                 text = {

--- a/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/home/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -51,6 +52,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.Font
@@ -128,15 +130,17 @@ fun HomeScreen(
                   isNoResultFound = isNoResultFound)
             }
             if (isSearchActive) {
+                val horizontalPlacement = LocalConfiguration.current.screenWidthDp * 0.6f
+
               Box(
                   modifier =
-                      Modifier.padding(290.dp, 25.dp, 25.dp, 235.dp)
-                          .width(200.dp)
+                      Modifier.padding(PaddingValues(horizontalPlacement.dp, 24.dp, 0.dp, 0.dp))
+                          .fillMaxWidth().fillMaxHeight()
                           .testTag("DropDownBox")) {
                     DropdownMenu(
                         expanded = showFilterDropdown,
                         onDismissRequest = { showFilterDropdown = false },
-                        modifier = Modifier.testTag("DropDownFilter")) {
+                        modifier = Modifier.padding(10.dp).width(400.dp).testTag("DropDownFilter")) {
                           FilterType.entries.forEach { filterType ->
                             DropdownMenuItem(
                                 text = {

--- a/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/MapOverview.kt
@@ -525,13 +525,13 @@ fun Map(
                           verticalArrangement = Arrangement.Center,
                           horizontalAlignment = Alignment.Start) {
                             Text(
-                                text = mapViewModel.selectedPin.value?.description ?: "",
+                                text = mapViewModel.selectedPin.value?.name ?: "",
                                 fontSize = 20.sp,
                                 fontFamily = Montserrat,
                                 fontWeight = FontWeight.Bold,
                                 color = md_theme_light_onPrimary)
                             Text(
-                                text = mapViewModel.selectedPin.value?.name ?: "",
+                                text = mapViewModel.selectedPin.value?.description ?: "",
                                 fontSize = 12.sp,
                                 fontFamily = Montserrat,
                                 fontWeight = FontWeight.Normal,

--- a/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/map/RecordScreen.kt
@@ -420,7 +420,7 @@ fun Map(
                                   fontSize = 16.sp,
                                   fontFamily = Montserrat,
                                   fontWeight = FontWeight.Normal,
-                                  lineHeight = 10.sp),
+                                  lineHeight = 20.sp),
                           colors =
                               OutlinedTextFieldDefaults.colors(
                                   unfocusedTextColor = md_theme_light_onPrimary,


### PR DESCRIPTION
This PR makes changes to the UI to look cleaner and more correct.
It addresses issues #260 #272 #273 

The changes includes :
1. [Fixed splitting filter text, taking into account screen height and width](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/commit/91eefab421ab4fe3d50f91131f029f481fe6f9c7) + Increased width of search dropdown so that it covers / hides  the itineraries
### Before 
![WhatsApp Image 2024-05-27 at 10 44 01](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/b74063f5-019b-4179-90aa-46c8843527e1=10x40)


### After
#### Note: it's on the small phone but displays better on the normal pixel 
<img width="258" alt="Screenshot 2024-05-29 at 12 28 23" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/c274f258-eab8-458b-bbed-356545121860">
 <br/>
<br/>

  2. [Fixed description display bug](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/commit/bcdc2e4774fcf9f493624f8a7ee03dd5064964bf)

### Before 
<img width="283" alt="Screenshot 2024-05-29 at 09 50 52" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/b656f90d-163d-49f4-a86c-cdf71fe24269">

### After
<img width="374" alt="Screenshot 2024-05-29 at 11 31 24" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/6c7983cf-b4a1-4c89-b5ff-20ecd3366f7d">

 <br/>
<br/>

  3. [Exchanged description with title in the popup](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/commit/8da827c8db1da69b6e920500550efce6f85a0408)

### Before 
<img width="342" alt="Screenshot 2024-05-29 at 11 35 23" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/a581c6e7-e7d5-4ec4-917e-abf7cd5e514a">

### After 
<img width="365" alt="Screenshot 2024-05-29 at 12 14 09" src="https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/73180998/3ba36094-933c-4979-808d-cd5da9ae4292">
