### PR TITLE
Update the offline screen

### DIFF
--- a/app/src/main/java/com/example/triptracker/view/OfflineScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/OfflineScreen.kt
@@ -80,7 +80,7 @@ fun OfflineScreen(navigation: Navigation, onRetry: () -> Unit) {
                 tint = color // Blinking effect
                 )
             Spacer(
-                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.025f).dp))
+                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.022f).dp))
             Text(
                 text = "Try again when you're back",
                 fontFamily = Montserrat,

--- a/app/src/main/java/com/example/triptracker/view/OfflineScreen.kt
+++ b/app/src/main/java/com/example/triptracker/view/OfflineScreen.kt
@@ -6,11 +6,12 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AirplanemodeActive
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.SignalWifiOff
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -41,13 +43,13 @@ fun OfflineScreen(navigation: Navigation, onRetry: () -> Unit) {
 
   val color by
       animateColorAsState(
-          targetValue = if (blink) Color.Black else md_theme_grey,
+          targetValue = if (blink) MaterialTheme.colorScheme.inverseSurface else md_theme_grey,
           animationSpec =
               infiniteRepeatable(
                   animation = tween(durationMillis = 1500), repeatMode = RepeatMode.Reverse),
           label = "")
 
-  /** Blinking effect for the airplane icon. */
+  /** Blinking effect for the wifi off icon. */
   LaunchedEffect(blink) { blink = false }
 
   Scaffold(bottomBar = { NavigationBar(navigation = navigation) }) { innerPadding ->
@@ -55,39 +57,64 @@ fun OfflineScreen(navigation: Navigation, onRetry: () -> Unit) {
         modifier = Modifier.padding(innerPadding).fillMaxSize(),
         contentAlignment = Alignment.Center) {
           Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Box(
-                modifier = Modifier.fillMaxWidth().padding(start = 30.dp, end = 30.dp),
-                contentAlignment = Alignment.Center) {
-                  Text(
-                      text =
-                          "Whoops! No internet? Try again when you're back in the land of Wi-Fi!",
-                      fontFamily = Montserrat,
-                      fontSize = 24.sp,
-                      color = Color.Black)
-                }
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(
+                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.17f).dp))
+            Text(
+                text = "Wooops !",
+                fontFamily = Montserrat,
+                fontWeight = FontWeight.Bold,
+                fontSize = (LocalConfiguration.current.screenHeightDp * 0.030f).sp,
+                color = MaterialTheme.colorScheme.inverseSurface)
+            Text(
+                text = "No internet ?",
+                fontFamily = Montserrat,
+                fontWeight = FontWeight.Bold,
+                fontSize = (LocalConfiguration.current.screenHeightDp * 0.030f).sp,
+                color = MaterialTheme.colorScheme.inverseSurface)
+            Spacer(
+                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.075f).dp))
             Icon(
-                imageVector = Icons.Default.AirplanemodeActive,
+                imageVector = Icons.Default.SignalWifiOff,
                 contentDescription = "Airplane Mode Active",
-                modifier = Modifier.size(100.dp),
+                modifier = Modifier.size((LocalConfiguration.current.screenHeightDp * 0.090f).dp),
                 tint = color // Blinking effect
                 )
-            Spacer(modifier = Modifier.height(100.dp))
+            Spacer(
+                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.025f).dp))
+            Text(
+                text = "Try again when you're back",
+                fontFamily = Montserrat,
+                fontSize = (LocalConfiguration.current.screenHeightDp * 0.018f).sp,
+                color = MaterialTheme.colorScheme.inverseSurface)
+            Text(
+                text = "in the land of Wi-Fi!",
+                fontFamily = Montserrat,
+                fontSize = (LocalConfiguration.current.screenHeightDp * 0.018f).sp,
+                color = MaterialTheme.colorScheme.inverseSurface)
+            Spacer(
+                modifier = Modifier.height((LocalConfiguration.current.screenHeightDp * 0.15f).dp))
             FilledTonalButton(
                 onClick = { onRetry() },
-                modifier = Modifier.padding(16.dp),
+                modifier =
+                    Modifier.width((LocalConfiguration.current.screenHeightDp * 0.18f).dp)
+                        .height((LocalConfiguration.current.screenHeightDp * 0.07f).dp),
                 colors =
                     ButtonDefaults.filledTonalButtonColors(
                         containerColor = md_theme_orange, contentColor = Color.White)) {
                   Icon(
                       imageVector = Icons.Default.Refresh,
                       contentDescription = "Refresh",
+                      modifier =
+                          Modifier.size((LocalConfiguration.current.screenHeightDp * 0.03f).dp),
                       tint = Color.White)
-                  Spacer(modifier = Modifier.width(8.dp))
+                  Spacer(
+                      modifier =
+                          Modifier.width((LocalConfiguration.current.screenHeightDp * 0.010f).dp))
                   Text(
                       text = "Retry",
                       fontFamily = Montserrat,
                       fontWeight = FontWeight.SemiBold,
+                      fontSize = (LocalConfiguration.current.screenHeightDp * 0.025f).sp,
                       color = Color.White)
                 }
           }


### PR DESCRIPTION
This PR update the offline screen to resemble the Figma, adjust to all screen sizes and include the dark mode.

**Before:**
![CleanShot 2024-05-29 at 21 59 49](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/7c1947fc-18c6-44bd-8489-a0e589904473)
![CleanShot 2024-05-29 at 21 59 18](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/03053c52-22e8-4c77-8b4a-8b2781209b74)





**After:**
![CleanShot 2024-05-29 at 23 00 05](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/4eb82896-b184-4fa0-b472-a755b8b03082)
![CleanShot 2024-05-29 at 22 59 44](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/b65602e3-89a7-4474-8b2e-eed7fce1d2a1)
![CleanShot 2024-05-29 at 22 52 36](https://github.com/EPFL-SwEnt-2024-LaStartUp/TripTracker/assets/100281310/8a12d176-3340-492b-8a98-12212534c8ae)
