### PR TITLE
End2End Test Pt. 1

### DIFF
--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,0 +1,14 @@
+package com.example.triptracker
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class E2ETest {
+    
+
+
+
+
+
+}

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,11 +1,6 @@
 package com.example.triptracker
 
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Home
-import androidx.compose.material.icons.outlined.Person
-import androidx.compose.material.icons.outlined.Place
-import androidx.compose.material.icons.outlined.RadioButtonChecked
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.remember
@@ -18,45 +13,20 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.navigation.NavController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.example.triptracker.itinerary.MockItineraryList
-import com.example.triptracker.model.network.Connection
 import com.example.triptracker.model.profile.MutableUserProfile
-import com.example.triptracker.model.profile.UserProfile
-import com.example.triptracker.model.repository.ItineraryRepository
-import com.example.triptracker.model.repository.UserProfileRepository
-import com.example.triptracker.userProfile.MockUserList
-import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
-import com.example.triptracker.view.OfflineScreen
 import com.example.triptracker.view.Route
-import com.example.triptracker.view.TopLevelDestination
 import com.example.triptracker.view.home.HomeScreen
-import com.example.triptracker.view.map.MapOverview
-import com.example.triptracker.view.map.RecordScreen
 import com.example.triptracker.view.profile.UserProfileEditScreen
 import com.example.triptracker.view.profile.UserProfileFavourite
-import com.example.triptracker.view.profile.UserProfileFollowers
-import com.example.triptracker.view.profile.UserProfileFollowing
 import com.example.triptracker.view.profile.UserProfileFriendsFinder
 import com.example.triptracker.view.profile.UserProfileMyTrips
 import com.example.triptracker.view.profile.UserProfileOverview
 import com.example.triptracker.view.profile.UserProfileSettings
-import com.example.triptracker.view.profile.UserView
-import com.example.triptracker.viewmodel.HomeViewModel
-import com.example.triptracker.viewmodel.UserProfileViewModel
-import io.mockk.MockKAnnotations
-import io.mockk.every
-import io.mockk.impl.annotations.RelaxedMockK
-import io.mockk.junit4.MockKRule
-import io.mockk.mockk
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -64,107 +34,106 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class E2ETest {
 
-    @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    var profile= MutableUserProfile()
+  var profile = MutableUserProfile()
 
-    @Test
-    fun profileScreenFlow(){
+  @Test
+  fun profileScreenFlow() {
 
-        composeTestRule.setContent {
-            Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                val navController = rememberNavController()
-                val navigation = remember(navController) { Navigation(navController) }
-                NavHost(
-                    navController = navController,
-                    startDestination = Route.PROFILE,
-                ) {
-                    composable(Route.HOME) { HomeScreen(navigation) }
-                    composable(Route.FRIENDS) {
-                        UserProfileFriendsFinder(navigation = navigation, profile = profile)
-                    }
-                    composable(Route.PROFILE) {
-                        UserProfileOverview(navigation = navigation, profile = profile)
-                    }
-                    composable(Route.MYTRIPS) {
-                        UserProfileMyTrips(
-                            navigation = navigation,
-                            userProfile = profile,
-                        )
-                    }
-                    composable(Route.EDIT) {
-                        UserProfileEditScreen(navigation = navigation, profile = profile)
-                    }
-                    composable(Route.SETTINGS) { UserProfileSettings(navigation) }
-                    composable(Route.FAVORITES) {
-                        UserProfileFavourite(navigation = navigation, userProfile = profile)
-                    }
-                }
-            }
-
+    composeTestRule.setContent {
+      Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        val navController = rememberNavController()
+        val navigation = remember(navController) { Navigation(navController) }
+        NavHost(
+            navController = navController,
+            startDestination = Route.PROFILE,
+        ) {
+          composable(Route.HOME) { HomeScreen(navigation) }
+          composable(Route.FRIENDS) {
+            UserProfileFriendsFinder(navigation = navigation, profile = profile)
+          }
+          composable(Route.PROFILE) {
+            UserProfileOverview(navigation = navigation, profile = profile)
+          }
+          composable(Route.MYTRIPS) {
+            UserProfileMyTrips(
+                navigation = navigation,
+                userProfile = profile,
+            )
+          }
+          composable(Route.EDIT) {
+            UserProfileEditScreen(navigation = navigation, profile = profile)
+          }
+          composable(Route.SETTINGS) { UserProfileSettings(navigation) }
+          composable(Route.FAVORITES) {
+            UserProfileFavourite(navigation = navigation, userProfile = profile)
+          }
         }
-
-        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-
-        //travel to the friends screen
-        composeTestRule.onNodeWithTag("FriendsButton").assertHasClickAction()
-        composeTestRule.onNodeWithTag("FriendsButton").performClick()
-
-        //verify that the favorites screen is open
-        composeTestRule.onNodeWithTag("FriendsFinderScreen").assertIsDisplayed()
-
-        //Go back and assert we are in the profile screen
-        composeTestRule.onNodeWithTag("GoBackButton").performClick()
-        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-
-        //travel to the favorites
-        composeTestRule.onNodeWithTag("FavoritesButton").assertHasClickAction()
-        composeTestRule.onNodeWithTag("FavoritesButton").performClick()
-
-        //verify that the favorites screen is open
-        composeTestRule.onNodeWithTag("UserProfileFavouriteScreen").assertIsDisplayed()
-
-        //Go back and assert we are in the profile screen
-        composeTestRule.onNodeWithTag("GoBackButton").performClick()
-        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-
-        //travel to the settings
-        composeTestRule.onNodeWithTag("SettingsButton").assertHasClickAction()
-        composeTestRule.onNodeWithTag("SettingsButton").performClick()
-
-        //verify that the followers screen is open
-        composeTestRule.onNodeWithTag("UserProfileSettings").assertIsDisplayed()
-
-        //Change privacy to private
-        composeTestRule.onNodeWithTag("ProfilePrivacyButton").performClick()
-
-        //Go back and assert we are in the profile screen
-        composeTestRule.onNodeWithTag("GoBackButton").performClick()
-        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-
-        //travel to the my trips
-        composeTestRule.onNodeWithTag("MyTripsButton").assertHasClickAction()
-        composeTestRule.onNodeWithTag("MyTripsButton").performClick()
-
-        //verify that the my trips screen is open
-        composeTestRule.onNodeWithTag("UserProfileMyTripsScreen").assertIsDisplayed()
-
-        //Go back and assert we are in the profile screen
-        composeTestRule.onNodeWithTag("GoBackButton").performClick()
-        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-
-        //Edit profile
-        composeTestRule.onNodeWithContentDescription("Edit").assertHasClickAction()
-        composeTestRule.onNodeWithContentDescription("Edit").performClick()
-
-        //verify that the edit screen is open
-        composeTestRule.onNodeWithTag("UserProfileEditScreen").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Save").isDisplayed()
+      }
     }
 
+    composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
 
+    // travel to the friends screen
+    composeTestRule.onNodeWithTag("FriendsButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("FriendsButton").performClick()
 
+    // verify that the favorites screen is open
+    composeTestRule.onNodeWithTag("FriendsFinderScreen").assertIsDisplayed()
 
+    // Go back and assert we are in the profile screen
+    composeTestRule.onNodeWithTag("GoBackButton").performClick()
+    composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
 
+    // travel to the favorites
+    composeTestRule.onNodeWithTag("FavoritesButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("FavoritesButton").performClick()
 
+    // verify that the favorites screen is open
+    composeTestRule.onNodeWithTag("UserProfileFavouriteScreen").assertIsDisplayed()
+
+    // Go back and assert we are in the profile screen
+    composeTestRule.onNodeWithTag("GoBackButton").performClick()
+    composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
+    // travel to the settings
+    composeTestRule.onNodeWithTag("SettingsButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("SettingsButton").performClick()
+
+    // verify that the followers screen is open
+    composeTestRule.onNodeWithTag("UserProfileSettings").assertIsDisplayed()
+
+    // Change privacy to private
+    composeTestRule.onNodeWithTag("ProfilePrivacyButton").performClick()
+
+    // Go back and assert we are in the profile screen
+    composeTestRule.onNodeWithTag("GoBackButton").performClick()
+    composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
+    // travel to the my trips
+    composeTestRule.onNodeWithTag("MyTripsButton").assertHasClickAction()
+    composeTestRule.onNodeWithTag("MyTripsButton").performClick()
+
+    // verify that the my trips screen is open
+    composeTestRule.onNodeWithTag("UserProfileMyTripsScreen").assertIsDisplayed()
+
+    // Go back and assert we are in the profile screen
+    composeTestRule.onNodeWithTag("GoBackButton").performClick()
+    composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
+    // Edit profile
+    composeTestRule.onNodeWithContentDescription("Edit").assertHasClickAction()
+    composeTestRule.onNodeWithContentDescription("Edit").performClick()
+
+    // verify that the edit screen is open
+    composeTestRule.onNodeWithTag("UserProfileEditScreen").assertIsDisplayed()
+
+    // input into the field
+    composeTestRule.onNodeWithText("Save").isDisplayed()
+
+    // Go back and assert we are in the profile screen
+    composeTestRule.onNodeWithTag("GoBackButton").performClick()
+    composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,11 +1,15 @@
 package com.example.triptracker
 
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Place
 import androidx.compose.material.icons.outlined.RadioButtonChecked
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -60,65 +64,27 @@ class E2ETest {
 
     @get:Rule val composeTestRule = createComposeRule()
 
-    @RelaxedMockK private lateinit var userProfilevm: UserProfileViewModel
-    @RelaxedMockK private lateinit var homevm: HomeViewModel
-    @RelaxedMockK private lateinit var mockNavigation: Navigation
-    @RelaxedMockK private lateinit var connection: Connection
-    val profile = MutableUserProfile()
-
-
-    //setup navhostcontroller
-
-    @Before
-    fun setup() {
-
-        mockNavigation = mockk(relaxed = true)
-        userProfilevm = mockk(relaxed = true)
-        homevm = mockk(relaxed = true)
-        connection = mockk(relaxed = true)
-
-
-        every { mockNavigation.getTopLevelDestinations() } returns
-                listOf(
-                    TopLevelDestination(Route.HOME, Icons.Outlined.Home, "Home"),
-                    TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps"),
-                    TopLevelDestination(Route.RECORD, Icons.Outlined.RadioButtonChecked, "Record"),
-                    TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile"),
-                )
-
-
-
-    }
-
-
+    var profile= MutableUserProfile()
 
     @Test
     fun profileScreenFlow(){
 
-        userProfilevm = mockk {
-            every { getUserProfileList() } returns
-                    listOf(UserProfile("email@example.com", "Test User", "Stupid", "Yesterday"))
-            every { getUserProfile(any(), any()) } coAnswers
-                    {
-                        secondArg<(UserProfile?) -> Unit>()
-                            .invoke(UserProfile("email@example.com", "Test User", "Stupid", "Yesterday"))
-                    }
-            every { onConnectionRefresh() } returns true
-            every { setProfile(any()) } returns Unit
-        }
+
         composeTestRule.setContent {
-            val navController = rememberNavController()
-            val navigation = remember(navController) { Navigation(navController) }
-            NavHost(
-                navController = navController,
-                startDestination = Route.PROFILE,
-            ) {
-                composable(Route.HOME) { HomeScreen(navigation) }
-                composable(Route.FRIENDS) {
-                    UserProfileFriendsFinder(navigation = navigation, profile = profile)
-                }
-                composable(Route.PROFILE) {
-                    UserProfileOverview(navigation = navigation, profile = profile)
+            Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                val navController = rememberNavController()
+                val navigation = remember(navController) { Navigation(navController) }
+                NavHost(
+                    navController = navController,
+                    startDestination = Route.PROFILE,
+                ) {
+                    composable(Route.HOME) { HomeScreen(navigation) }
+                    composable(Route.FRIENDS) {
+                        UserProfileFriendsFinder(navigation = navigation, profile = profile)
+                    }
+                    composable(Route.PROFILE) {
+                        UserProfileOverview(navigation = navigation, profile = profile)
+                    }
                 }
             }
 
@@ -127,7 +93,6 @@ class E2ETest {
         composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
         composeTestRule.onNodeWithTag("FriendsButton").assertHasClickAction()
         composeTestRule.onNodeWithTag("FriendsButton").performClick()
-
         //verify that the favorites screen is open
 
 

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -38,6 +38,10 @@ class E2ETest {
 
   var profile = MutableUserProfile()
 
+
+  /*
+      Test to check the flow of the profile screen navigating through different screens
+   */
   @Test
   fun profileScreenFlow() {
 
@@ -135,5 +139,15 @@ class E2ETest {
     // Go back and assert we are in the profile screen
     composeTestRule.onNodeWithTag("GoBackButton").performClick()
     composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
   }
+
+  /*
+    Test to check the flow of the app navigating through different places, to be implemented
+   */
+  @Test
+  fun appFlow(){
+
+  }
+
 }

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -85,18 +85,66 @@ class E2ETest {
                     composable(Route.PROFILE) {
                         UserProfileOverview(navigation = navigation, profile = profile)
                     }
+                    composable(Route.MYTRIPS) {
+                        UserProfileMyTrips(
+                            navigation = navigation,
+                            userProfile = profile,
+                        )
+                    }
+                    composable(Route.SETTINGS) { UserProfileSettings(navigation) }
+                    composable(Route.FAVORITES) {
+                        UserProfileFavourite(navigation = navigation, userProfile = profile)
+                    }
                 }
             }
 
         }
 
         composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
+        //travel to the friends screen
         composeTestRule.onNodeWithTag("FriendsButton").assertHasClickAction()
         composeTestRule.onNodeWithTag("FriendsButton").performClick()
+
         //verify that the favorites screen is open
+        composeTestRule.onNodeWithTag("FriendsFinderScreen").assertIsDisplayed()
 
+        //Go back and assert we are in the profile screen
+        composeTestRule.onNodeWithTag("GoBackButton").performClick()
+        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
 
+        //travel to the favorites
+        composeTestRule.onNodeWithTag("FavoritesButton").assertHasClickAction()
+        composeTestRule.onNodeWithTag("FavoritesButton").performClick()
 
+        //verify that the favorites screen is open
+        composeTestRule.onNodeWithTag("UserProfileFavouriteScreen").assertIsDisplayed()
+
+        //Go back and assert we are in the profile screen
+        composeTestRule.onNodeWithTag("GoBackButton").performClick()
+        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
+        //travel to the settings
+        composeTestRule.onNodeWithTag("SettingsButton").assertHasClickAction()
+        composeTestRule.onNodeWithTag("SettingsButton").performClick()
+
+        //verify that the followers screen is open
+        composeTestRule.onNodeWithTag("UserProfileSettings").assertIsDisplayed()
+
+        //Go back and assert we are in the profile screen
+        composeTestRule.onNodeWithTag("GoBackButton").performClick()
+        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+
+        //travel to the my trips
+        composeTestRule.onNodeWithTag("MyTripsButton").assertHasClickAction()
+        composeTestRule.onNodeWithTag("MyTripsButton").performClick()
+
+        //verify that the my trips screen is open
+        composeTestRule.onNodeWithTag("UserProfileMyTripsScreen").assertIsDisplayed()
+
+        //Go back and assert we are in the profile screen
+        composeTestRule.onNodeWithTag("GoBackButton").performClick()
+        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
 
 
     }

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -107,9 +107,6 @@ class E2ETest {
     // verify that the followers screen is open
     composeTestRule.onNodeWithTag("UserProfileSettings").assertIsDisplayed()
 
-    // Change privacy to private
-    composeTestRule.onNodeWithTag("ProfilePrivacyButton").performClick()
-
     // Go back and assert we are in the profile screen
     composeTestRule.onNodeWithTag("GoBackButton").performClick()
     composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -139,9 +139,4 @@ class E2ETest {
     composeTestRule.onNodeWithTag("GoBackButton").performClick()
     composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
   }
-
-  /*
-   Test to check the flow of the app navigating through different places, to be implemented
-  */
-  @Test fun appFlow() {}
 }

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,6 +1,20 @@
 package com.example.triptracker
 
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.triptracker.itinerary.MockItineraryList
+import com.example.triptracker.model.profile.MutableUserProfile
+import com.example.triptracker.model.repository.ItineraryRepository
+import com.example.triptracker.model.repository.UserProfileRepository
+import com.example.triptracker.userProfile.MockUserList
+import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.home.HomeScreen
+import com.example.triptracker.viewmodel.HomeViewModel
+import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit4.MockKRule
+import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -8,11 +22,52 @@ import org.junit.runner.RunWith
 class E2ETest {
 
 
+    @get:Rule
+    val composeTestRule = createComposeRule()
+    @get:Rule
+    val mockkRule = MockKRule(this)
 
+    @RelaxedMockK
+    lateinit var mockNav: Navigation
+    @RelaxedMockK
+    private lateinit var mockViewModel: HomeViewModel
+    @RelaxedMockK
+    private lateinit var mockItineraryRepository: ItineraryRepository
+    // @RelaxedMockK private  lateinit var mockUserProfileRepository: UserProfileRepository
+    @RelaxedMockK
+    private lateinit var mockUserProfileRepository: UserProfileRepository
+    @RelaxedMockK
+    private lateinit var mockUserProfileViewModel: UserProfileViewModel
+    // private lateinit var mockUserProfileViewModel: UserProfileViewModel
+    @RelaxedMockK
+    private lateinit var mockProfile: MutableUserProfile
+
+    val mockList = MockItineraryList()
+    val mockItineraries = mockList.getItineraries()
+
+    val mockUserList = MockUserList()
+    val mockUsers = mockUserList.getUserProfiles()
+    val mockMail = "test@gmail.com"
+
+
+    @Before
+    fun setUp() {
+
+    }
 
 
     @Test
     fun navigateUserScreen(){
+
+        composeTestRule.setContent {
+            HomeScreen(
+                navigation = mockNav,
+                homeViewModel = mockViewModel,
+                userProfileViewModel = mockUserProfileViewModel,
+                test = true)
+        }
+
+
 
 
     }

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,11 +1,23 @@
 package com.example.triptracker
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Home
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.Place
+import androidx.compose.material.icons.outlined.RadioButtonChecked
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.navigation.NavController
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.itinerary.MockItineraryList
 import com.example.triptracker.model.network.Connection
@@ -14,9 +26,23 @@ import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.model.repository.ItineraryRepository
 import com.example.triptracker.model.repository.UserProfileRepository
 import com.example.triptracker.userProfile.MockUserList
+import com.example.triptracker.view.LoginScreen
 import com.example.triptracker.view.Navigation
+import com.example.triptracker.view.OfflineScreen
+import com.example.triptracker.view.Route
+import com.example.triptracker.view.TopLevelDestination
 import com.example.triptracker.view.home.HomeScreen
+import com.example.triptracker.view.map.MapOverview
+import com.example.triptracker.view.map.RecordScreen
+import com.example.triptracker.view.profile.UserProfileEditScreen
+import com.example.triptracker.view.profile.UserProfileFavourite
+import com.example.triptracker.view.profile.UserProfileFollowers
+import com.example.triptracker.view.profile.UserProfileFollowing
+import com.example.triptracker.view.profile.UserProfileFriendsFinder
+import com.example.triptracker.view.profile.UserProfileMyTrips
 import com.example.triptracker.view.profile.UserProfileOverview
+import com.example.triptracker.view.profile.UserProfileSettings
+import com.example.triptracker.view.profile.UserView
 import com.example.triptracker.viewmodel.HomeViewModel
 import com.example.triptracker.viewmodel.UserProfileViewModel
 import io.mockk.MockKAnnotations
@@ -38,6 +64,10 @@ class E2ETest {
     @RelaxedMockK private lateinit var homevm: HomeViewModel
     @RelaxedMockK private lateinit var mockNavigation: Navigation
     @RelaxedMockK private lateinit var connection: Connection
+    val profile = MutableUserProfile()
+
+
+    //setup navhostcontroller
 
     @Before
     fun setup() {
@@ -46,9 +76,19 @@ class E2ETest {
         userProfilevm = mockk(relaxed = true)
         homevm = mockk(relaxed = true)
         connection = mockk(relaxed = true)
+
+
+        every { mockNavigation.getTopLevelDestinations() } returns
+                listOf(
+                    TopLevelDestination(Route.HOME, Icons.Outlined.Home, "Home"),
+                    TopLevelDestination(Route.MAPS, Icons.Outlined.Place, "Maps"),
+                    TopLevelDestination(Route.RECORD, Icons.Outlined.RadioButtonChecked, "Record"),
+                    TopLevelDestination(Route.PROFILE, Icons.Outlined.Person, "Profile"),
+                )
+
+
+
     }
-
-
 
 
 
@@ -66,18 +106,31 @@ class E2ETest {
             every { onConnectionRefresh() } returns true
             every { setProfile(any()) } returns Unit
         }
-
         composeTestRule.setContent {
-            UserProfileOverview(
-                profile = MutableUserProfile(),
-                navigation = mockNavigation,
-                homeViewModel = homevm,
-                userProfileViewModel = userProfilevm)
+            val navController = rememberNavController()
+            val navigation = remember(navController) { Navigation(navController) }
+            NavHost(
+                navController = navController,
+                startDestination = Route.PROFILE,
+            ) {
+                composable(Route.HOME) { HomeScreen(navigation) }
+                composable(Route.FRIENDS) {
+                    UserProfileFriendsFinder(navigation = navigation, profile = profile)
+                }
+                composable(Route.PROFILE) {
+                    UserProfileOverview(navigation = navigation, profile = profile)
+                }
+            }
+
         }
 
         composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("FavoritesButton").assertHasClickAction()
-        composeTestRule.onNodeWithTag("FavoritesButton").performClick()
+        composeTestRule.onNodeWithTag("FriendsButton").assertHasClickAction()
+        composeTestRule.onNodeWithTag("FriendsButton").performClick()
+
+        //verify that the favorites screen is open
+
+
 
 
 

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -38,10 +38,9 @@ class E2ETest {
 
   var profile = MutableUserProfile()
 
-
   /*
-      Test to check the flow of the profile screen navigating through different screens
-   */
+     Test to check the flow of the profile screen navigating through different screens
+  */
   @Test
   fun profileScreenFlow() {
 
@@ -139,15 +138,10 @@ class E2ETest {
     // Go back and assert we are in the profile screen
     composeTestRule.onNodeWithTag("GoBackButton").performClick()
     composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
-
   }
 
   /*
-    Test to check the flow of the app navigating through different places, to be implemented
-   */
-  @Test
-  fun appFlow(){
-
-  }
-
+   Test to check the flow of the app navigating through different places, to be implemented
+  */
+  @Test fun appFlow() {}
 }

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,20 +1,26 @@
 package com.example.triptracker
 
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.itinerary.MockItineraryList
+import com.example.triptracker.model.network.Connection
 import com.example.triptracker.model.profile.MutableUserProfile
+import com.example.triptracker.model.profile.UserProfile
 import com.example.triptracker.model.repository.ItineraryRepository
 import com.example.triptracker.model.repository.UserProfileRepository
 import com.example.triptracker.userProfile.MockUserList
 import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.home.HomeScreen
+import com.example.triptracker.view.profile.UserProfileOverview
 import com.example.triptracker.viewmodel.HomeViewModel
 import com.example.triptracker.viewmodel.UserProfileViewModel
 import io.mockk.MockKAnnotations
+import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
 import io.mockk.mockk
@@ -26,19 +32,52 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class E2ETest {
 
+    @get:Rule val composeTestRule = createComposeRule()
 
-
+    @RelaxedMockK private lateinit var userProfilevm: UserProfileViewModel
+    @RelaxedMockK private lateinit var homevm: HomeViewModel
+    @RelaxedMockK private lateinit var mockNavigation: Navigation
+    @RelaxedMockK private lateinit var connection: Connection
 
     @Before
-    fun setUp() {
+    fun setup() {
 
-
+        mockNavigation = mockk(relaxed = true)
+        userProfilevm = mockk(relaxed = true)
+        homevm = mockk(relaxed = true)
+        connection = mockk(relaxed = true)
     }
+
+
+
 
 
     @Test
     fun profileScreenFlow(){
 
+        userProfilevm = mockk {
+            every { getUserProfileList() } returns
+                    listOf(UserProfile("email@example.com", "Test User", "Stupid", "Yesterday"))
+            every { getUserProfile(any(), any()) } coAnswers
+                    {
+                        secondArg<(UserProfile?) -> Unit>()
+                            .invoke(UserProfile("email@example.com", "Test User", "Stupid", "Yesterday"))
+                    }
+            every { onConnectionRefresh() } returns true
+            every { setProfile(any()) } returns Unit
+        }
+
+        composeTestRule.setContent {
+            UserProfileOverview(
+                profile = MutableUserProfile(),
+                navigation = mockNavigation,
+                homeViewModel = homevm,
+                userProfileViewModel = userProfilevm)
+        }
+
+        composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("FavoritesButton").assertHasClickAction()
+        composeTestRule.onNodeWithTag("FavoritesButton").performClick()
 
 
 

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,6 +1,9 @@
 package com.example.triptracker
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.triptracker.itinerary.MockItineraryList
 import com.example.triptracker.model.profile.MutableUserProfile
@@ -11,8 +14,10 @@ import com.example.triptracker.view.Navigation
 import com.example.triptracker.view.home.HomeScreen
 import com.example.triptracker.viewmodel.HomeViewModel
 import com.example.triptracker.viewmodel.UserProfileViewModel
+import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit4.MockKRule
+import io.mockk.mockk
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -22,50 +27,17 @@ import org.junit.runner.RunWith
 class E2ETest {
 
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
-    @get:Rule
-    val mockkRule = MockKRule(this)
-
-    @RelaxedMockK
-    lateinit var mockNav: Navigation
-    @RelaxedMockK
-    private lateinit var mockViewModel: HomeViewModel
-    @RelaxedMockK
-    private lateinit var mockItineraryRepository: ItineraryRepository
-    // @RelaxedMockK private  lateinit var mockUserProfileRepository: UserProfileRepository
-    @RelaxedMockK
-    private lateinit var mockUserProfileRepository: UserProfileRepository
-    @RelaxedMockK
-    private lateinit var mockUserProfileViewModel: UserProfileViewModel
-    // private lateinit var mockUserProfileViewModel: UserProfileViewModel
-    @RelaxedMockK
-    private lateinit var mockProfile: MutableUserProfile
-
-    val mockList = MockItineraryList()
-    val mockItineraries = mockList.getItineraries()
-
-    val mockUserList = MockUserList()
-    val mockUsers = mockUserList.getUserProfiles()
-    val mockMail = "test@gmail.com"
 
 
     @Before
     fun setUp() {
 
+
     }
 
 
     @Test
-    fun navigateUserScreen(){
-
-        composeTestRule.setContent {
-            HomeScreen(
-                navigation = mockNav,
-                homeViewModel = mockViewModel,
-                userProfileViewModel = mockUserProfileViewModel,
-                test = true)
-        }
+    fun profileScreenFlow(){
 
 
 

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -1,11 +1,22 @@
 package com.example.triptracker
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class E2ETest {
-    
+
+
+
+
+
+    @Test
+    fun navigateUserScreen(){
+
+
+    }
+
 
 
 

--- a/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
+++ b/app/src/androidTest/java/com/example/triptracker/e2eTest.kt
@@ -12,9 +12,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.navigation.NavController
 import androidx.navigation.NavType
@@ -69,7 +71,6 @@ class E2ETest {
     @Test
     fun profileScreenFlow(){
 
-
         composeTestRule.setContent {
             Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
                 val navController = rememberNavController()
@@ -90,6 +91,9 @@ class E2ETest {
                             navigation = navigation,
                             userProfile = profile,
                         )
+                    }
+                    composable(Route.EDIT) {
+                        UserProfileEditScreen(navigation = navigation, profile = profile)
                     }
                     composable(Route.SETTINGS) { UserProfileSettings(navigation) }
                     composable(Route.FAVORITES) {
@@ -131,6 +135,9 @@ class E2ETest {
         //verify that the followers screen is open
         composeTestRule.onNodeWithTag("UserProfileSettings").assertIsDisplayed()
 
+        //Change privacy to private
+        composeTestRule.onNodeWithTag("ProfilePrivacyButton").performClick()
+
         //Go back and assert we are in the profile screen
         composeTestRule.onNodeWithTag("GoBackButton").performClick()
         composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
@@ -146,7 +153,13 @@ class E2ETest {
         composeTestRule.onNodeWithTag("GoBackButton").performClick()
         composeTestRule.onNodeWithTag("ProfileOverview").assertIsDisplayed()
 
+        //Edit profile
+        composeTestRule.onNodeWithContentDescription("Edit").assertHasClickAction()
+        composeTestRule.onNodeWithContentDescription("Edit").performClick()
 
+        //verify that the edit screen is open
+        composeTestRule.onNodeWithTag("UserProfileEditScreen").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Save").isDisplayed()
     }
 
 


### PR DESCRIPTION
## Create E2E Test
The long awaited E2E is finally here, this is the first part testing the profile screen.

### Add End-to-End Test for Profile Screen Navigation
This PR introduces a comprehensive end-to-end (E2E) test for the profile screen navigation flow within the app. The test ensures that users can seamlessly navigate through various profile-related screens, perform actions, and return to the profile overview screen, verifying the integrity and usability of the navigation.

### Method
Instead of mocking with mockk, it was simpler to create a NavHost and perform actual navigation through parts of the app to test that everything is working well.
